### PR TITLE
ci: fix Cirque test failures by pinning otbr-agent OpenThread version

### DIFF
--- a/integrations/docker/build.sh
+++ b/integrations/docker/build.sh
@@ -84,6 +84,15 @@ if [[ ${*/--no-cache//} != "${*}" ]]; then
     BUILD_ARGS+=(--no-cache)
 fi
 
+# Collect --build-arg key=value pairs from the command line for forwarding to docker build
+prev_arg=""
+for arg in "$@"; do
+    if [[ "$prev_arg" == "--build-arg" ]]; then
+        BUILD_ARGS+=("--build-arg" "$arg")
+    fi
+    prev_arg="$arg"
+done
+
 [[ ${*/--skip-build//} != "${*}" ]] || {
     docker build "${BUILD_ARGS[@]}" --build-arg TARGETPLATFORM="$TARGET_PLATFORM_TYPE" --build-arg VERSION="$VERSION" -t "$GHCR_ORG/$ORG/$IMAGE:$VERSION" .
     docker image prune --force

--- a/integrations/docker/images/stage-2/chip-cirque-device-base/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-cirque-device-base/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:24.04
 
 ARG OT_BR_POSIX_CHECKOUT=main
+ARG OPENTHREAD_CHECKOUT=main
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PLATFORM=ubuntu
@@ -46,9 +47,12 @@ RUN apt-get update \
       && cd ot-br-posix \
       && git init \
       && git remote add origin https://github.com/openthread/ot-br-posix \
-      && git fetch origin $OT_BR_POSIX_CHECKOUT --depth=1 \
+      && git fetch origin $OT_BR_POSIX_CHECKOUT \
       && git reset --hard FETCH_HEAD \
-      && git submodule update --init --depth=1 \
+      && git submodule update --init \
+      && (cd third_party/openthread/repo \
+          && git fetch origin $OPENTHREAD_CHECKOUT \
+          && git checkout FETCH_HEAD) \
       && ./script/bootstrap \
       && ./script/setup)\
   && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \

--- a/scripts/tests/cirque_tests.sh
+++ b/scripts/tests/cirque_tests.sh
@@ -125,7 +125,9 @@ function cirquetest_bootstrap() {
 
     git config --global --add safe.directory /home/runner/work/connectedhomeip/connectedhomeip
 
-    "$REPO_DIR"/integrations/docker/images/stage-2/chip-cirque-device-base/build.sh --build-arg OT_BR_POSIX_CHECKOUT="$OT_BR_POSIX_CHECKOUT"
+    "$REPO_DIR"/integrations/docker/images/stage-2/chip-cirque-device-base/build.sh \
+        --build-arg OT_BR_POSIX_CHECKOUT="$OT_BR_POSIX_CHECKOUT" \
+        --build-arg OPENTHREAD_CHECKOUT="$OPENTHREAD_CHECKOUT"
 
     __cirquetest_build_ot_lazy
     pip3 install --break-system-packages -r requirements_nogrpc.txt


### PR DESCRIPTION
#### Summary

All 14 Cirque integration tests are consistently failing on CI with every `ot-ctl` command returning `connect session failed: No such file or directory`, preventing the Thread network from forming. This is caused by a version mismatch between `otbr-agent` (inside the `chip-cirque-device-base` Docker image) and `ot-rcp` (the simulated OpenThread radio).

**Root cause:** `build.sh` was not forwarding `--build-arg` parameters to `docker build`. The Dockerfile always fell back to the default `ARG OT_BR_POSIX_CHECKOUT=main`, pulling the latest `ot-br-posix` HEAD instead of the pinned submodule commit. Different CI runs on different days got different `otbr-agent` versions — the newer `otbr-agent` (`0.3.0-86431d2`) calls `otPlatRadioSetMacKey()`, a Spinel command unsupported by the cached `ot-rcp` (`OPENTHREAD/3fec404`), causing immediate crash.

**Evidence:** Comparing device logs from a successful run ([job/92185934631](https://github.com/telink-semi/connectedhomeip/actions/runs/30967934599/job/92185934631)) vs a failed run ([job/92240339446](https://github.com/telink-semi/connectedhomeip/actions/runs/30985838824/job/92240339446)):

```
# Successful: otbr-agent starts normally
otbr-agent[30]: [NOTE]-AGENT---: Running 0.3.0-ec20ce2
otbr-agent[30]: [INFO]-APP-----: Radio Co-processor version: OPENTHREAD/3fec404

# Failed: otbr-agent crashes immediately
otbr-agent[30]: [NOTE]-AGENT---: Running 0.3.0-86431d2
otbr-agent[30]: 00:00:00.004 [C] Platform------: otPlatRadioSetMacKey() at radio.cpp:964: InvalidArgument
```

All other CI-related files (`Dockerfile`, `cachekey.sh`, submodule pins, `cirque_tests.sh`) are identical between the two runs — this is purely CI environment drift.

**Fix:** Three files changed to make the Docker image build deterministic — `otbr-agent` will now always use the exact same OpenThread version as `ot-rcp` (the Matter SDK's pinned submodule commit):

- `build.sh`: forward `--build-arg key=value` pairs to `docker build`
- `Dockerfile`: add `OPENTHREAD_CHECKOUT` build arg; after submodule init, explicitly checkout OpenThread to the pinned commit
- `cirque_tests.sh`: pass `OPENTHREAD_CHECKOUT` to `build.sh`

#### Related issues

N/A

#### Testing

Verified by comparing Cirque test artifacts (device logs, Flask logs) from the successful and failed CI runs linked above. The root cause was identified through log diffing. The fix will be validated by re-running Cirque CI on this PR.

#### Readability checklist

- [x] PR title follows [title formatting](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
- [x] Apply the [coding style](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
- [x] PR size is short
- [x] Try to avoid "squashing" and "force-update" in commit history
- [x] CI time didn't increase