### PR TITLE
[telink] Update v1.2.0 release notes with latest build data, add TL521X and concurrent/CS targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,10 +148,12 @@ MB flash, Software Version 2 for DFU/OTA images, etc.).
 
 Refer to the board README for the app + board combination you want to build:
 
-#### Lighting App (TL3238X / TL7218X)
+#### Lighting App (TL3238X / TL521X / TL7218X)
 
 -   TL3238X:
     [`examples/lighting-app/telink/boards/tl3238x_README.md`](examples/lighting-app/telink/boards/tl3238x_README.md)
+-   TL5218X:
+    [`examples/lighting-app/telink/boards/tl5218x_README.md`](examples/lighting-app/telink/boards/tl5218x_README.md)
 -   TL7218X:
     [`examples/lighting-app/telink/boards/tl7218x_README.md`](examples/lighting-app/telink/boards/tl7218x_README.md)
 
@@ -162,11 +164,20 @@ Refer to the board README for the app + board combination you want to build:
 -   TL7218X Retention:
     [`examples/light-switch-app/telink/boards/tl7218x_retention_README.md`](examples/light-switch-app/telink/boards/tl7218x_retention_README.md)
 
+#### Concurrent Mode (TL3238X / TL7218X)
+
+-   TL3238X BLE + Thread Concurrent:
+    [`examples/lighting-app/telink/boards/tl3238x_concurrent_README.md`](examples/lighting-app/telink/boards/tl3238x_concurrent_README.md)
+-   TL7218X BLE + Thread Concurrent:
+    [`examples/lighting-app/telink/boards/tl7218x_concurrent_README.md`](examples/lighting-app/telink/boards/tl7218x_concurrent_README.md)
+-   TL7218X BLE + Thread Concurrent + Channel Sounding:
+    [`examples/lighting-app/telink/boards/tl7218x_concurrent_cs_README.md`](examples/lighting-app/telink/boards/tl7218x_concurrent_cs_README.md)
+
 > **Note:** LZMA compression is **required** for 2 MB flash with OTA. Build
 > Software Version 2 (via the flag documented in each `*_README.md`) to generate
 > the DFU/OTA upgrade images (`merged_dfu.lzma.bin`, `matter.ota`). The same
-> `*_README.md` files also cover dual-mode (Matter + Zigbee) and 4 MB flash
-> configurations.
+> `*_README.md` files also cover dual-mode (Matter + Zigbee), BLE + Thread
+> concurrent mode, Channel Sounding (CS), and 4 MB flash configurations.
 
 ### Flashing Firmware
 
@@ -180,11 +191,8 @@ our
 
 | Board          | Chip Family | Series | Status               |
 | -------------- | ----------- | ------ | -------------------- |
-| tlsr9518adk80d | TLSR951X    | B91    | Telink Zephyr HAL_V1 |
-| tlsr9528a      | TLSR952X    | B92    | Telink Zephyr HAL_V1 |
-| tlsr9118bdk40d | TLSR911X    | W91    | -                    |
-| tl3218x        | TL321X      | -      | Telink Zephyr HAL_V1 |
 | tl3238x        | TL323X      | -      | Telink Zephyr HAL_V2 |
+| tl5218x        | TL521X      | -      | Telink Zephyr HAL_V2 |
 | tl7218x        | TL721X      | -      | Telink Zephyr HAL_V2 |
 
 ---

--- a/README.md
+++ b/README.md
@@ -117,19 +117,14 @@ the high-level steps are:
    [Matter Developer Guide](https://doc.telink-semi.cn/doc/en/software/res/sdk/matter/telink_matter_developer_guide_en/)
    for the exact `west` commands.
 
-4. **Fetch the Telink BLE SDK binary** — `west update` does **not** fetch
-   `tl_ble_sdk` automatically (Zephyr CI disallows binary modules). Run
-   `./hal_v2/fetch_sdk.sh` inside `modules/hal/telink/` of the Zephyr SDK to
-   download the pre-built BLE stack.
-
-5. **Get the Telink Matter SDK (this repo)** — clone the `dev-tlk_v1.5` branch
+4. **Get the Telink Matter SDK (this repo)** — clone the `dev-tlk_v1.5` branch
    of this repository next to the Zephyr SDK.
 
-6. **Point the Matter SDK at the Zephyr SDK** — export `TELINK_ZEPHYR_BASE` so
+5. **Point the Matter SDK at the Zephyr SDK** — export `TELINK_ZEPHYR_BASE` so
    the Matter build system can find Zephyr, the Telink HAL and the toolchain.
    This variable must be set in every shell used for Matter builds.
 
-7. **Bootstrap & activate the Matter build environment** — run the Matter
+6. **Bootstrap & activate the Matter build environment** — run the Matter
    `scripts/activate.sh` bootstrap once to install `gn`, `ninja`, `pigweed` and
    the Python dependencies, then source it in every new shell before building.
 

--- a/README.md
+++ b/README.md
@@ -189,11 +189,11 @@ our
 
 ## 📱 Supported Boards
 
-| Board          | Chip Family | Series | Status               |
-| -------------- | ----------- | ------ | -------------------- |
-| tl3238x        | TL323X      | -      | Telink Zephyr HAL_V2 |
-| tl5218x        | TL521X      | -      | Telink Zephyr HAL_V2 |
-| tl7218x        | TL721X      | -      | Telink Zephyr HAL_V2 |
+| Board   | Chip Family | Series | Status               |
+| ------- | ----------- | ------ | -------------------- |
+| tl3238x | TL323X      | -      | Telink Zephyr HAL_V2 |
+| tl5218x | TL521X      | -      | Telink Zephyr HAL_V2 |
+| tl7218x | TL721X      | -      | Telink Zephyr HAL_V2 |
 
 ---
 

--- a/docs/platforms/telink/releases/README_BUILD_SCRIPT.md
+++ b/docs/platforms/telink/releases/README_BUILD_SCRIPT.md
@@ -103,12 +103,12 @@ Each board's zip archive contains:
 
 ## Supported sample applications
 
-| Application      | Description                                                            |
-| ---------------- | ---------------------------------------------------------------------- |
+| Application      | Description                                                               |
+| ---------------- | ------------------------------------------------------------------------- |
 | lighting-app     | Lighting application (supports OTA, Factory Data, LZMA, Shell, Dual-Mode) |
-| light-switch-app | Light switch application (supports OTA, LZMA, Factory Data, Retention) |
-| bridge-app       | Bridge application                                                     |
-| window-app       | Window covering application                                            |
+| light-switch-app | Light switch application (supports OTA, LZMA, Factory Data, Retention)    |
+| bridge-app       | Bridge application                                                        |
+| window-app       | Window covering application                                               |
 
 ## Script features
 
@@ -157,14 +157,14 @@ The build target format is `telink-<board>-<app>[-<options>]`, for example:
 
 -   `telink-tl3238x-light-ota-factory-data-4mb` - TL3238X lighting application
     with OTA, Factory Data, 4MB Flash
--   `telink-tl3238x-light-ota-compress-lzma-factory-data-dual-mode` -
-    TL3238X lighting application with OTA, LZMA, Factory Data, BLE + Thread
-    concurrent mode
+-   `telink-tl3238x-light-ota-compress-lzma-factory-data-dual-mode` - TL3238X
+    lighting application with OTA, LZMA, Factory Data, BLE + Thread concurrent
+    mode
 -   `telink-tl7218x_retention-light-switch-ota-compress-lzma-factory-data` -
     TL7218X Retention light switch application
--   `telink-tl7218x-light-ota-compress-lzma-factory-data-dual-mode` -
-    TL7218X lighting application with OTA, LZMA, Factory Data, BLE + Thread
-    concurrent mode
+-   `telink-tl7218x-light-ota-compress-lzma-factory-data-dual-mode` - TL7218X
+    lighting application with OTA, LZMA, Factory Data, BLE + Thread concurrent
+    mode
 -   `telink-tl5218x-light-ota-factory-data-4mb` - TL521X lighting application
     with OTA, Factory Data, 4MB Flash
 -   `telink-tl5218x-light-ota-factory-data-4mb` - TL521X lighting application

--- a/docs/platforms/telink/releases/README_BUILD_SCRIPT.md
+++ b/docs/platforms/telink/releases/README_BUILD_SCRIPT.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The script `docs/platforms/telink/releases/build_and_update_matter_notes.py`
+The script `docs/platforms/telink/releases/generate_and_update_matter_notes.py`
 can:
 
 1. Build all Telink board Matter sample applications (using `build_examples.py`)
@@ -16,7 +16,7 @@ can:
 
 ## Files
 
--   `docs/platforms/telink/releases/build_and_update_matter_notes.py` - main
+-   `docs/platforms/telink/releases/generate_and_update_matter_notes.py` - main
     build and update script (alongside the release note working copy)
 -   `docs/platforms/telink/releases/telink_release_notes.md` - release note
     working copy (in the same directory as the script; the script reads and
@@ -51,7 +51,7 @@ source ./scripts/activate.sh -p all,telink
 
 ```bash
 cd /home/ubuntu/zephyrproject/connectedhomeip
-python3 docs/platforms/telink/releases/build_and_update_matter_notes.py
+python3 docs/platforms/telink/releases/generate_and_update_matter_notes.py
 ```
 
 This will:
@@ -97,31 +97,18 @@ Each board's zip archive contains:
 
 ## Supported boards
 
-1. tlsr9518adk80d (TLSR951X/B91)
-2. tlsr9528a (TLSR952X/B92)
-3. tlsr9118bdk40d (TLSR911X/W91)
-4. tl3218x (TL321X)
-5. tl3238x (TL323X)
-6. tl7218x (TL721X)
+1. tl3238x (TL323X)
+2. tl5218x (TL521X)
+3. tl7218x (TL721X)
 
 ## Supported sample applications
 
-| Application              | Description                                                    |
-| ------------------------ | -------------------------------------------------------------- |
-| lighting-app             | Lighting application (supports OTA, Factory Data, LZMA, Shell) |
-| light-switch-app         | Light switch application (supports OTA, LZMA, Factory Data)    |
-| bridge-app               | Bridge application                                             |
-| window-app               | Window covering application                                    |
-| air-quality-sensor-app   | Air quality sensor application                                 |
-| all-clusters-app         | All-clusters application                                       |
-| all-clusters-minimal-app | Minimal all-clusters application (supports NFC Payload)        |
-| contact-sensor-app       | Contact sensor application                                     |
-| lock-app                 | Door lock application (supports DFU over SMP)                  |
-| smoke-co-alarm-app       | Smoke/CO alarm application                                     |
-| pump-controller-app      | Pump controller application                                    |
-| shell                    | Shell application                                              |
-| thermostat               | Thermostat application                                         |
-| ota-requestor-app        | OTA requestor application                                      |
+| Application      | Description                                                            |
+| ---------------- | ---------------------------------------------------------------------- |
+| lighting-app     | Lighting application (supports OTA, Factory Data, LZMA, Shell, Dual-Mode) |
+| light-switch-app | Light switch application (supports OTA, LZMA, Factory Data, Retention) |
+| bridge-app       | Bridge application                                                     |
+| window-app       | Window covering application                                            |
 
 ## Script features
 
@@ -170,10 +157,18 @@ The build target format is `telink-<board>-<app>[-<options>]`, for example:
 
 -   `telink-tl3238x-light-ota-factory-data-4mb` - TL3238X lighting application
     with OTA, Factory Data, 4MB Flash
+-   `telink-tl3238x-light-ota-compress-lzma-factory-data-dual-mode` -
+    TL3238X lighting application with OTA, LZMA, Factory Data, BLE + Thread
+    concurrent mode
 -   `telink-tl7218x_retention-light-switch-ota-compress-lzma-factory-data` -
     TL7218X Retention light switch application
--   `telink-tlsr9518adk80d-light-ota-rpc-factory-data-4mb` - B91 lighting
-    application with RPC, OTA, Factory Data
+-   `telink-tl7218x-light-ota-compress-lzma-factory-data-dual-mode` -
+    TL7218X lighting application with OTA, LZMA, Factory Data, BLE + Thread
+    concurrent mode
+-   `telink-tl5218x-light-ota-factory-data-4mb` - TL521X lighting application
+    with OTA, Factory Data, 4MB Flash
+-   `telink-tl5218x-light-ota-factory-data-4mb` - TL521X lighting application
+    with OTA, Factory Data, 4MB Flash, Dual-Mode
 
 Available options:
 
@@ -186,3 +181,4 @@ Available options:
 -   `4mb` - 4MB Flash
 -   `log-progress` - reduce log output (progress and errors only)
 -   `nfc-payload` - NFC Payload support
+-   `dual-mode` - enable BLE + Thread concurrent mode (TL323X, TL721X)

--- a/docs/platforms/telink/releases/generate_and_update_matter_notes.py
+++ b/docs/platforms/telink/releases/generate_and_update_matter_notes.py
@@ -174,8 +174,6 @@ class TelinkMatterBuildManager:
 
         for board, app_name, target_suffix in self.build_targets:
             full_target = f"telink-{target_suffix}"
-            # Output directory used by build_examples.py
-            output_dir_name = full_target.replace("telink-", "telink-")
             # build_examples.py outputs to out/<full_target>
             log_filename = f"build_{target_suffix}.log"
             log_file = self.build_logs_dir / log_filename

--- a/docs/platforms/telink/releases/generate_and_update_matter_notes.py
+++ b/docs/platforms/telink/releases/generate_and_update_matter_notes.py
@@ -33,7 +33,6 @@ Usage (run from the connectedhomeip repo root):
     python3 docs/platforms/telink/releases/generate_and_update_matter_notes.py --skip-firmware  # skip firmware packaging
 """
 
-import os
 import re
 import subprocess
 import shutil
@@ -398,7 +397,7 @@ class TelinkMatterBuildManager:
         for board_name, family_name in self.board_order:
             # Find matching family in data
             family_key = None
-            for fk in data.keys():
+            for fk in data:
                 if fk.startswith(family_name.split("/")[0]) or family_name.startswith(fk):
                     family_key = fk
                     break

--- a/docs/platforms/telink/releases/generate_and_update_matter_notes.py
+++ b/docs/platforms/telink/releases/generate_and_update_matter_notes.py
@@ -34,10 +34,10 @@ Usage (run from the connectedhomeip repo root):
 """
 
 import re
-import subprocess
 import shutil
+import subprocess
 from pathlib import Path
-from typing import List, Dict, Tuple, Optional
+from typing import Dict, List, Optional, Tuple
 
 
 class TelinkMatterBuildManager:

--- a/docs/platforms/telink/releases/generate_and_update_matter_notes.py
+++ b/docs/platforms/telink/releases/generate_and_update_matter_notes.py
@@ -1,0 +1,610 @@
+#!/usr/bin/env python3
+#
+#    Copyright (c) 2026 Telink Semiconductor Co., Ltd.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+"""
+Telink Matter SDK - Generate and Release Notes Update Script
+
+This script:
+  1. Builds all Telink Matter examples for supported boards using build_examples.py
+  2. Captures build logs and extracts memory usage information (RAM/ROM)
+  3. Updates the Release Note working copy
+     (docs/platforms/telink/releases/telink_release_notes.md) in-place,
+     using table format for the Resource Usage section
+  4. Collects firmware files (zephyr.bin/.elf/.hex, .config, zephyr.dts) and
+     creates per-board zip archives
+
+Usage (run from the connectedhomeip repo root):
+    python3 docs/platforms/telink/releases/generate_and_update_matter_notes.py                  # full run
+    python3 docs/platforms/telink/releases/generate_and_update_matter_notes.py --skip-build     # skip building
+    python3 docs/platforms/telink/releases/generate_and_update_matter_notes.py --skip-firmware  # skip firmware packaging
+"""
+
+import os
+import re
+import subprocess
+import shutil
+from pathlib import Path
+from typing import List, Dict, Tuple, Optional
+
+
+class TelinkMatterBuildManager:
+    """Manages building Telink Matter examples and generating release notes."""
+
+    def __init__(self, repo_root: Optional[Path] = None):
+        # This script lives in docs/platforms/telink/releases/. Detect the repo
+        # root by walking up from the script's location looking for the `.git`
+        # marker, so the script works regardless of where it is invoked from.
+        if repo_root is not None:
+            self.repo_root = repo_root
+        else:
+            candidate = Path(__file__).resolve().parent
+            while candidate != candidate.parent:
+                if (candidate / ".git").exists():
+                    break
+                candidate = candidate.parent
+            self.repo_root = candidate
+
+        # Output directories
+        self.release_dir = self.repo_root / "build_for_release"
+        self.release_dir.mkdir(exist_ok=True)
+
+        self.build_logs_dir = self.release_dir / "build_logs"
+        self.build_logs_dir.mkdir(exist_ok=True)
+
+        self.firmware_output_dir = self.release_dir / "firmware"
+        self.firmware_output_dir.mkdir(exist_ok=True)
+
+        # Release Note working copy (read and write in-place; only the
+        # Resource Usage section is regenerated, the rest is hand-maintained).
+        # The working copy lives next to this script in
+        # docs/platforms/telink/releases/. A versioned snapshot
+        # (telink_release_notes_<tag>.md) is produced by
+        # scripts/tools/telink/package_telink_firmware.sh at release time.
+        self.output_path = Path(__file__).resolve().parent / "telink_release_notes.md"
+
+        # Board family mapping (board -> chip family)
+        self.board_family = {
+            "tlsr9518adk80d": "TLSR951X",
+            "tlsr9528a": "TLSR952X",
+            "tlsr9528a_retention": "TLSR952X",
+            "tlsr9118bdk40d": "TLSR911X",
+            "tl3218x": "TL321X",
+            "tl3218x_ml3m": "TL321X",
+            "tl3218x_retention": "TL321X",
+            "tl3238x": "TL323X",
+            "tl3238x_retention": "TL323X",
+            "tl7218x": "TL721X",
+            "tl7218x_retention": "TL721X",
+        }
+
+        # Display order for boards in the release note
+        self.board_order = [
+            ("tlsr9518adk80d", "TLSR951X/B91"),
+            ("tlsr9528a", "TLSR952X/B92"),
+            ("tl3218x", "TL321X"),
+            ("tl3238x", "TL323X"),
+            ("tl7218x", "TL721X"),
+            ("tlsr9118bdk40d", "TLSR911X/W91"),
+        ]
+
+        # Define all build targets (board, app, target_string)
+        # target_string is the full build_examples.py target (without the 'telink-' prefix)
+        self.build_targets = self._get_build_targets()
+
+    def _get_build_targets(self) -> List[Tuple[str, str, str]]:
+        """Define all Matter build targets for Telink platforms.
+
+        Returns a list of (board, app_name, target_suffix) tuples where:
+          - board: the board identifier (without 'telink-' prefix)
+          - app_name: human-readable app name for display
+          - target_suffix: the full target string passed to build_examples.py
+                           (e.g. 'tl3238x-light-ota-factory-data-4mb')
+        """
+        targets = []
+
+        # -------------------------- TL323X --------------------------
+        targets.extend([
+            ("tl3238x", "lighting-app", "tl3238x-light-ota-factory-data-4mb"),
+            ("tl3238x_retention", "light-switch-app", "tl3238x_retention-light-switch-ota-compress-lzma-factory-data"),
+        ])
+
+        # -------------------------- TL721X --------------------------
+        targets.extend([
+            ("tl7218x", "lighting-app", "tl7218x-light-ota-compress-lzma-shell-factory-data"),
+            ("tl7218x", "bridge-app", "tl7218x-bridge"),
+            ("tl7218x", "window-app", "tl7218x-window-covering"),
+            ("tl7218x_retention", "light-switch-app", "tl7218x_retention-light-switch-ota-compress-lzma-factory-data"),
+        ])
+
+        # -------------------------- TLSR952X/B92 --------------------------
+        targets.extend([
+            ("tlsr9528a", "air-quality-sensor-app", "tlsr9528a_retention-air-quality-sensor"),
+            ("tlsr9528a", "all-clusters-minimal-app", "tlsr9528a-all-clusters-minimal-nfc-payload"),
+            ("tlsr9528a", "contact-sensor-app", "tlsr9528a_retention-contact-sensor"),
+            ("tlsr9528a", "light-switch-app", "tlsr9528a-light-switch-ota-compress-lzma-shell-factory-data"),
+            ("tlsr9528a", "lock-app", "tlsr9528a-lock-dfu-smp"),
+            ("tlsr9528a", "smoke-co-alarm-app", "tlsr9528a_retention-smoke-co-alarm"),
+        ])
+
+        # -------------------------- TLSR911X/W91 --------------------------
+        targets.extend([
+            ("tlsr9118bdk40d", "lighting-app", "tlsr9118bdk40d-light-ota-factory-data-log-progress"),
+            ("tlsr9118bdk40d", "all-clusters-app", "tlsr9118bdk40d-all-clusters"),
+            ("tlsr9118bdk40d", "thermostat", "tlsr9118bdk40d-thermostat"),
+        ])
+
+        # -------------------------- TLSR951X/B91 --------------------------
+        targets.extend([
+            ("tlsr9518adk80d", "lighting-app", "tlsr9518adk80d-light-ota-rpc-factory-data-4mb"),
+            ("tlsr9518adk80d", "pump-controller-app", "tlsr9518adk80d-pump-controller"),
+            ("tlsr9518adk80d", "shell", "tlsr9518adk80d-shell"),
+        ])
+
+        # -------------------------- TL321X --------------------------
+        targets.extend([
+            ("tl3218x", "lighting-app", "tl3218x-light-ota-compress-lzma-shell-factory-data"),
+            ("tl3218x", "ota-requestor-app", "tl3218x-ota-requestor"),
+            ("tl3218x_retention", "light-switch-app", "tl3218x_retention-light-switch-ota-factory-data"),
+        ])
+
+        return targets
+
+    def build_all(self):
+        """Build all Telink Matter examples using build_examples.py."""
+        print("=" * 80)
+        print("Building all Telink Matter examples...")
+        print("=" * 80)
+        print()
+
+        success_count = 0
+        fail_count = 0
+
+        for board, app_name, target_suffix in self.build_targets:
+            full_target = f"telink-{target_suffix}"
+            # Output directory used by build_examples.py
+            output_dir_name = full_target.replace("telink-", "telink-")
+            # build_examples.py outputs to out/<full_target>
+            log_filename = f"build_{target_suffix}.log"
+            log_file = self.build_logs_dir / log_filename
+
+            print(f"  Building {full_target}...")
+            print(f"  App: {app_name}  Board: {board}")
+
+            # The build is run via scripts/build/build_examples.py
+            cmd = [
+                "./scripts/build/build_examples.py",
+                "--target", full_target,
+                "build",
+            ]
+
+            print(f"  Command: {' '.join(cmd)}")
+
+            # Run inside the build environment wrapper if available
+            run_in_build_env = self.repo_root / "scripts" / "run_in_build_env.sh"
+            if run_in_build_env.exists():
+                cmd = [str(run_in_build_env), " ".join(cmd)]
+
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                cwd=str(self.repo_root),
+                check=False,
+            )
+
+            # Write log file
+            with open(log_file, "w", encoding="utf-8") as f:
+                f.write(f"Target: {full_target}\n")
+                f.write(f"Board: {board}\n")
+                f.write(f"App: {app_name}\n\n")
+                f.write(f"Command: {' '.join(cmd)}\n\n")
+                f.write(f"STDOUT:\n{result.stdout}\n\n")
+                f.write(f"STDERR:\n{result.stderr}\n\n")
+                f.write(f"Return code: {result.returncode}\n")
+
+            if result.returncode == 0:
+                print(f"  Success! Log written to {log_file}")
+                success_count += 1
+            else:
+                print(f"  Failed! Log written to {log_file}")
+                fail_count += 1
+
+            print()
+
+        print("=" * 80)
+        print(f"Build complete! {success_count} succeeded, {fail_count} failed.")
+        print("=" * 80)
+
+    def extract_memory_info(self) -> Dict[str, Dict[str, List[Dict]]]:
+        """Extract memory usage information from build logs.
+
+        Returns a nested dict: {family: {board: [{name, memory: [{name,used,size,percent}]}}]}
+        """
+        data: Dict[str, Dict[str, List[Dict]]] = {}
+
+        print()
+        print("=" * 80)
+        print("Extracting memory usage information from logs...")
+        print("=" * 80)
+        print()
+
+        for log_file in self.build_logs_dir.glob("build_*.log"):
+            filename = log_file.name
+            # filename: build_<target_suffix>.log
+            target_suffix = filename[len("build_"):-len(".log")]
+
+            # Identify the board from the target suffix
+            board = None
+            app_name = None
+            for b in sorted(self.board_family.keys(), key=lambda x: -len(x)):
+                if target_suffix.startswith(b):
+                    board = b
+                    rest = target_suffix[len(b):]
+                    if rest.startswith("-"):
+                        rest = rest[1:]
+                    # The app name is the segment up to the next '-<option>'
+                    # Known app prefixes
+                    app_prefixes = [
+                        "light", "light-switch", "bridge", "window-covering",
+                        "air-quality-sensor", "all-clusters-minimal", "all-clusters",
+                        "contact-sensor", "lock", "smoke-co-alarm",
+                        "pump", "pump-controller", "shell",
+                        "temperature-measurement", "thermostat", "ota-requestor",
+                    ]
+                    for ap in app_prefixes:
+                        if rest.startswith(ap):
+                            app_name = ap
+                            break
+                    break
+
+            if not board:
+                continue
+
+            if not app_name:
+                app_name = target_suffix
+
+            # Read the log content
+            with open(log_file, "r", encoding="utf-8", errors="ignore") as f:
+                content = f.read()
+
+            # Find the "Memory region" section (Zephyr output)
+            idx = content.find("Memory region")
+            if idx == -1:
+                continue
+
+            # Extract memory region text
+            memory_end = content.find("Generating files from", idx)
+            if memory_end == -1:
+                memory_end = content.find("Loaded", idx)
+            if memory_end == -1:
+                memory_end = idx + 800
+
+            memory_text = content[idx:memory_end]
+
+            # Parse memory regions
+            memory_regions = []
+            lines = memory_text.split("\n")
+            for line in lines[1:]:
+                line = line.strip()
+                if not line:
+                    continue
+                if "IDT_LIST" in line:
+                    break
+
+                # Format: RAMILM:         21248 B      131072 B      16.21%
+                match = re.match(r"(\S+):\s*(\d+)\s*(\S+)\s*(\d+)\s*(\S+)\s*([\d.]+)%", line)
+                if match:
+                    name = match.group(1).rstrip(":")
+                    used = f"{match.group(2)} {match.group(3)}"
+                    size = f"{match.group(4)} {match.group(5)}"
+                    percent = f"{match.group(6)}%"
+                    memory_regions.append({
+                        "name": name,
+                        "used": used,
+                        "size": size,
+                        "percent": percent,
+                    })
+                else:
+                    # Format: RAM_ILM_N:         27 KB       128 KB     21.09%
+                    match2 = re.match(r"(\S+):\s*([\d.]+)\s*(\S+)\s*([\d.]+)\s*(\S+)\s*([\d.]+)%", line)
+                    if match2:
+                        name = match2.group(1).rstrip(":")
+                        used = f"{match2.group(2)} {match2.group(3)}"
+                        size = f"{match2.group(4)} {match2.group(5)}"
+                        percent = f"{match2.group(6)}%"
+                        memory_regions.append({
+                            "name": name,
+                            "used": used,
+                            "size": size,
+                            "percent": percent,
+                        })
+
+            if memory_regions:
+                # Map board to base board and family
+                base_board = board
+                # Strip retention/ml3m/ml7g/ml7m suffixes for grouping
+                for suffix in ["_retention", "_ml3m"]:
+                    if base_board.endswith(suffix):
+                        base_board = base_board[: -len(suffix)]
+                        break
+
+                family = self.board_family.get(board, base_board.upper())
+
+                if family not in data:
+                    data[family] = {}
+                if base_board not in data[family]:
+                    data[family][base_board] = []
+
+                # Build a display name for the sample (target suffix)
+                display_name = target_suffix
+
+                data[family][base_board].append({
+                    "name": display_name,
+                    "app": app_name,
+                    "memory": memory_regions,
+                })
+
+        total_samples = sum(len(b) for f in data.values() for b in f.values())
+        print(f"Processed {total_samples} samples successfully!")
+
+        return data
+
+    def update_release_notes(self, data: Dict[str, Dict[str, List[Dict]]]):
+        """Update the Telink release note working copy in-place."""
+        print()
+        print("=" * 80)
+        print(f"Updating {self.output_path.relative_to(self.repo_root)}...")
+        print("=" * 80)
+        print()
+
+        # Check that the release note file exists
+        if not self.output_path.exists():
+            print(f"Error: Release note file {self.output_path} does not exist!")
+            return
+
+        # Build the Resource Usage section (table format)
+        resource_usage_lines = []
+        resource_usage_lines.append("## 📊 Resource Usage (Code Size)")
+        resource_usage_lines.append("")
+        resource_usage_lines.append(
+            "This section shows the RAM and ROM usage for various Matter examples "
+            "on Telink platforms, built with the Matter SDK and Zephyr RTOS."
+        )
+        resource_usage_lines.append("")
+        resource_usage_lines.append("### Supported Boards")
+        resource_usage_lines.append("")
+        resource_usage_lines.append("| Board | Chip Family |")
+        resource_usage_lines.append("|-------|-------------|")
+        for board_name, family_name in self.board_order:
+            resource_usage_lines.append(f"| {board_name} | {family_name} |")
+        resource_usage_lines.append("")
+        resource_usage_lines.append("---")
+        resource_usage_lines.append("")
+
+        for board_name, family_name in self.board_order:
+            # Find matching family in data
+            family_key = None
+            for fk in data.keys():
+                if fk.startswith(family_name.split("/")[0]) or family_name.startswith(fk):
+                    family_key = fk
+                    break
+            if not family_key or board_name not in data.get(family_key, {}):
+                print(f"Warning: No data for {board_name} ({family_name})")
+                continue
+
+            resource_usage_lines.append(f"### {family_name} ({board_name})")
+            resource_usage_lines.append("")
+            resource_usage_lines.append("📈 **Resource Usage Details**")
+            resource_usage_lines.append("")
+
+            samples = sorted(data[family_key][board_name], key=lambda x: x["name"])
+
+            if not samples:
+                continue
+
+            # Use region names from the first sample as table headers
+            region_names = [r["name"] for r in samples[0]["memory"]]
+
+            # Table header
+            headers = ["Sample"] + region_names
+            resource_usage_lines.append("| " + " | ".join(headers) + " |")
+            resource_usage_lines.append("|" + "|".join(["---" for _ in headers]) + "|")
+
+            # Data rows
+            for sample in samples:
+                row = [f"**{sample['name']}**"]
+                region_map = {r["name"]: r for r in sample["memory"]}
+                for region_name in region_names:
+                    if region_name in region_map:
+                        r = region_map[region_name]
+                        row.append(f"{r['used']} ({r['percent']} of {r['size']})")
+                    else:
+                        row.append("N/A")
+                resource_usage_lines.append("| " + " | ".join(row) + " |")
+
+            resource_usage_lines.append("")
+            resource_usage_lines.append("---")
+            resource_usage_lines.append("")
+
+        # Read the release note and replace the Resource Usage section
+        with open(self.output_path, "r", encoding="utf-8") as f:
+            template_lines = f.read().split("\n")
+
+        new_lines = []
+        i = 0
+        while i < len(template_lines):
+            line = template_lines[i]
+
+            # Match the Resource Usage section start
+            if "Resource Usage" in line and line.startswith("#"):
+                # Add the generated Resource Usage content
+                new_lines.extend(resource_usage_lines)
+
+                # Skip the original section until "Additional Notes"
+                i += 1
+                while i < len(template_lines):
+                    if "Additional Notes" in template_lines[i] and template_lines[i].startswith("#"):
+                        break
+                    i += 1
+                continue
+
+            new_lines.append(line)
+            i += 1
+
+        # Write the final release note
+        with open(self.output_path, "w", encoding="utf-8") as f:
+            f.write("\n".join(new_lines))
+
+        print(f"Updated {self.output_path.relative_to(self.repo_root)} successfully!")
+
+    def collect_firmware(self):
+        """Collect firmware files from build output directories."""
+        print()
+        print("=" * 80)
+        print("Collecting firmware files...")
+        print("=" * 80)
+        print()
+
+        firmware_files = [
+            "zephyr.bin",
+            "zephyr.elf",
+            "zephyr.hex",
+            "zephyr.dts",
+            ".config",
+            "zephyr.signed.bin",
+            "mcuboot.bin",
+        ]
+
+        board_firmware: Dict[str, List[Dict]] = {}
+
+        for board, app_name, target_suffix in self.build_targets:
+            full_target = f"telink-{target_suffix}"
+            # build_examples.py outputs to out/<full_target>/zephyr/
+            build_output_dir = self.repo_root / "out" / full_target / "zephyr"
+
+            if not build_output_dir.exists():
+                print(f"  Skipping {full_target}: output dir not found")
+                continue
+
+            # Base board name (strip retention/ml3m/ml7g/ml7m suffixes)
+            base_board_name = board
+            for suffix in ["_retention", "_ml3m", "_ml7g", "_ml7m"]:
+                if base_board_name.endswith(suffix):
+                    base_board_name = base_board_name[: -len(suffix)]
+                    break
+
+            if base_board_name not in board_firmware:
+                board_firmware[base_board_name] = []
+
+            # Create firmware output directory
+            sample_firmware_dir = self.firmware_output_dir / base_board_name / target_suffix
+            sample_firmware_dir.mkdir(parents=True, exist_ok=True)
+
+            # Copy firmware files
+            copied_files = []
+            for fw_file in firmware_files:
+                src_file = build_output_dir / fw_file
+                if src_file.exists():
+                    dst_file = sample_firmware_dir / fw_file
+                    shutil.copy2(src_file, dst_file)
+                    copied_files.append(fw_file)
+
+            if copied_files:
+                board_firmware[base_board_name].append({
+                    "sample_name": target_suffix,
+                    "directory": sample_firmware_dir,
+                    "files": copied_files,
+                })
+                print(f"  Collected: {base_board_name}/{target_suffix} - {len(copied_files)} files")
+
+        return board_firmware
+
+    def create_firmware_archives(self, board_firmware: Dict[str, List[Dict]]):
+        """Create per-board firmware zip archives."""
+        print()
+        print("=" * 80)
+        print("Creating firmware archives...")
+        print("=" * 80)
+        print()
+
+        archives_created = []
+
+        for board_name, samples in board_firmware.items():
+            if not samples:
+                continue
+
+            archive_path = self.firmware_output_dir / f"{board_name}_matter_firmware.zip"
+
+            if archive_path.exists():
+                archive_path.unlink()
+
+            print(f"  Creating archive for {board_name}...")
+
+            import zipfile
+            with zipfile.ZipFile(archive_path, "w", zipfile.ZIP_DEFLATED) as zipf:
+                for sample in samples:
+                    sample_dir = sample["directory"]
+                    for file_name in sample["files"]:
+                        file_path = sample_dir / file_name
+                        arcname = f"{board_name}/{sample['sample_name']}/{file_name}"
+                        zipf.write(file_path, arcname)
+
+            archives_created.append(archive_path)
+            print(f"  Created: {archive_path}")
+
+        return archives_created
+
+    def run(self, build: bool = True, collect_firmware: bool = True):
+        """Run the full build + release note + firmware packaging flow."""
+        if build:
+            self.build_all()
+
+        data = self.extract_memory_info()
+        self.update_release_notes(data)
+
+        if collect_firmware:
+            board_firmware = self.collect_firmware()
+            self.create_firmware_archives(board_firmware)
+
+        print()
+        print("=" * 80)
+        print("All tasks complete!")
+        print("=" * 80)
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Build Telink Matter examples and update release notes."
+    )
+    parser.add_argument(
+        "--skip-build", action="store_true",
+        help="Skip building examples, just update release notes from existing logs"
+    )
+    parser.add_argument(
+        "--skip-firmware", action="store_true",
+        help="Skip collecting and archiving firmware"
+    )
+    args = parser.parse_args()
+
+    manager = TelinkMatterBuildManager()
+    manager.run(build=not args.skip_build, collect_firmware=not args.skip_firmware)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/platforms/telink/releases/telink_release_notes.md
+++ b/docs/platforms/telink/releases/telink_release_notes.md
@@ -27,15 +27,15 @@ Telink chips including TL323X, TL521X, and TL721X.
 
 ## ✨ Highlights
 
-| Category                    | Details                                                |
-| --------------------------- | ------------------------------------------------------ |
-| **Matter Support**          | Matter 1.5.1 protocol stack                            |
-| **Supported Chips**         | TL323X, TL521X, TL721X |
-| **Sample Apps**             | Lighting, Light Switch, Lock, Bridge, Thermostat, etc. |
-| **OTA**                     | OTA requestor and compress-LZMA support                |
-| **Factory Data**            | Factory data provisioning support                      |
-| **BLE/Thread Concurrent**   | BLE + Thread concurrent mode on TL323X and TL721X      |
-| **Channel Sounding**        | CS RAS reflector support on TL721X                     |
+| Category                  | Details                                                |
+| ------------------------- | ------------------------------------------------------ |
+| **Matter Support**        | Matter 1.5.1 protocol stack                            |
+| **Supported Chips**       | TL323X, TL521X, TL721X                                 |
+| **Sample Apps**           | Lighting, Light Switch, Lock, Bridge, Thermostat, etc. |
+| **OTA**                   | OTA requestor and compress-LZMA support                |
+| **Factory Data**          | Factory data provisioning support                      |
+| **BLE/Thread Concurrent** | BLE + Thread concurrent mode on TL323X and TL721X      |
+| **Channel Sounding**      | CS RAS reflector support on TL721X                     |
 
 ---
 
@@ -68,7 +68,7 @@ Thread network on selected Telink SoCs.
 | SoC Family | BLE-Only | Thread-Only | BLE + Thread Concurrent | Channel Sounding |
 | :--------: | :------: | :---------: | :---------------------: | :--------------: |
 |   TL323X   |    ✅    |     ✅      |           ✅            |        —         |
-|   TL521X   |    ✅    |     ✅      |           —             |        —         |
+|   TL521X   |    ✅    |     ✅      |            —            |        —         |
 |   TL721X   |    ✅    |     ✅      |           ✅            |        ✅        |
 
 > **Note:** BLE + Thread concurrent mode requires the `*_concurrent` board
@@ -79,9 +79,9 @@ Thread network on selected Telink SoCs.
 
 ## 🐛 Bug Fixes
 
-| Issue             | Description                                                                   |
-| ----------------- | ----------------------------------------------------------------------------- |
-| **Amazon Commissioning**  | Fix commissioning on Amazon when Channel Sounding is enabled          |
+| Issue                    | Description                                                  |
+| ------------------------ | ------------------------------------------------------------ |
+| **Amazon Commissioning** | Fix commissioning on Amazon when Channel Sounding is enabled |
 
 ---
 
@@ -143,12 +143,12 @@ support.
 
 ### Telink Matter SDK
 
-| Property          | Version                                                                                                               |
-| ----------------- | --------------------------------------------------------------------------------------------------------------------- |
-| **Branch**        | [pre_release-v1.2-v1.5-branch](https://github.com/telink-semi/connectedhomeip/tree/pre_release-v1.2-v1.5-branch)      |
-| **Target Commit** | [50cae34](https://github.com/telink-semi/connectedhomeip/commit/50cae34e79ecbd5af5644eb60f6aa564f6c48ab4)                                                    |
-| **Tag Name**      | [tl_v1.2.0-alpha-v1.5](https://github.com/telink-semi/connectedhomeip/releases/tag/tl_v1.2.0-alpha-v1.5)          |
-| **Release Type**  | Pre-Release (Alpha)                                                                                                   |
+| Property          | Version                                                                                                          |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------- |
+| **Branch**        | [pre_release-v1.2-v1.5-branch](https://github.com/telink-semi/connectedhomeip/tree/pre_release-v1.2-v1.5-branch) |
+| **Target Commit** | [50cae34](https://github.com/telink-semi/connectedhomeip/commit/50cae34e79ecbd5af5644eb60f6aa564f6c48ab4)        |
+| **Tag Name**      | [tl_v1.2.0-alpha-v1.5](https://github.com/telink-semi/connectedhomeip/releases/tag/tl_v1.2.0-alpha-v1.5)         |
+| **Release Type**  | Pre-Release (Alpha)                                                                                              |
 
 ### Chip &amp; Hardware Versions
 
@@ -195,9 +195,9 @@ example and the Telink chip platforms that support it (see
 -   **Supported but untested (🟡):** TL721X bridge-app and window-app are
     compiled successfully but have not been functionally validated.
 -   **Untested (·):** Combinations not listed are not built or validated.
--   TL323X / TL521X / TL721X are the latest Telink RISC-V SoC families.
-    Lighting and light-switch apps are supported across TL323X and TL721X;
-    TL521X supports lighting-app only.
+-   TL323X / TL521X / TL721X are the latest Telink RISC-V SoC families. Lighting
+    and light-switch apps are supported across TL323X and TL721X; TL521X
+    supports lighting-app only.
 -   The light-switch-app uses the `*_retention` board target (power management
     with retention RAM).
 -   For build commands per board/app, refer to the per-board `*_README.md` files
@@ -212,11 +212,11 @@ platforms, built with the Matter SDK and Zephyr RTOS.
 
 ### Supported Boards
 
-| Board    | Chip Family |
-| -------- | ----------- |
-| tl3238x  | TL323X      |
-| tl5218x  | TL521X      |
-| tl7218x  | TL721X      |
+| Board   | Chip Family |
+| ------- | ----------- |
+| tl3238x | TL323X      |
+| tl5218x | TL521X      |
+| tl7218x | TL721X      |
 
 ### TL323X/TL721X Matter (OTA + LZMA) Code Size
 
@@ -234,30 +234,30 @@ output (`Memory region` summary) of the build logs.
 
 📈 **Resource Usage Details**
 
-| App                  | Build Target                              | RAM_ILM_N                 | ROM                          | RAM                       |
-| -------------------- | ----------------------------------------- | ------------------------- | ---------------------------- | ------------------------- |
-| **lighting-app**     | `build_tl3238x_2m_flash_lzma`             | 54006 B (82.41% of 64 KB) | 960074 B (81.39% of 1152 KB) | 90464 B (92.02% of 96 KB) |
-| **light-switch-app** | `build_tl3238x_retention_lzma`            | 63734 B (97.25% of 64 KB) | 904554 B (76.68% of 1152 KB) | 84496 B (85.95% of 96 KB) |
-| **lighting-app**     | `build_tl3238x_concurrent_ota_lzma`       | 60168 B (91.81% of 64 KB) | 960080 B (81.39% of 1152 KB) | 90448 B (92.01% of 96 KB) |
+| App                  | Build Target                        | RAM_ILM_N                 | ROM                          | RAM                       |
+| -------------------- | ----------------------------------- | ------------------------- | ---------------------------- | ------------------------- |
+| **lighting-app**     | `build_tl3238x_2m_flash_lzma`       | 54006 B (82.41% of 64 KB) | 960074 B (81.39% of 1152 KB) | 90464 B (92.02% of 96 KB) |
+| **light-switch-app** | `build_tl3238x_retention_lzma`      | 63734 B (97.25% of 64 KB) | 904554 B (76.68% of 1152 KB) | 84496 B (85.95% of 96 KB) |
+| **lighting-app**     | `build_tl3238x_concurrent_ota_lzma` | 60168 B (91.81% of 64 KB) | 960080 B (81.39% of 1152 KB) | 90448 B (92.01% of 96 KB) |
 
 #### TL721X (tl7218x)
 
 📈 **Resource Usage Details**
 
-| App                  | Build Target                                  | RAMILM / RAM_ILM_N         | RAM_DLM                   | ROM                          | RAM                         |
-| -------------------- | --------------------------------------------- | -------------------------- | ------------------------- | ---------------------------- | --------------------------- |
-| **lighting-app**     | `build_tl7218x_lzma`                   | 93376 B (35.62% of 256 KB) | —                         | 938542 B (79.56% of 1152 KB) | 55200 B (21.06% of 256 KB)  |
-| **light-switch-app** | `build_tl7218x_retention_lzma`         | 47098 B (35.93% of 128 KB) | 8346 B (3.18% of 256 KB)  | 881487 B (74.72% of 1152 KB) | 102696 B (78.35% of 128 KB) |
-| **lighting-app**     | `build_tl7218x_concurrent_ota_lzma`    | 102072 B (38.94% of 256 KB) | —                        | 950564 B (80.58% of 1152 KB) | 55360 B (21.12% of 256 KB)  |
-| **lighting-app**     | `build_tl7218x_concurrent_cs_ota_lzma` | 146248 B (55.79% of 256 KB) | —                   | 1071138 B (90.80% of 1152 KB) | 124120 B (47.35% of 256 KB) |
+| App                  | Build Target                           | RAMILM / RAM_ILM_N          | RAM_DLM                  | ROM                           | RAM                         |
+| -------------------- | -------------------------------------- | --------------------------- | ------------------------ | ----------------------------- | --------------------------- |
+| **lighting-app**     | `build_tl7218x_lzma`                   | 93376 B (35.62% of 256 KB)  | —                        | 938542 B (79.56% of 1152 KB)  | 55200 B (21.06% of 256 KB)  |
+| **light-switch-app** | `build_tl7218x_retention_lzma`         | 47098 B (35.93% of 128 KB)  | 8346 B (3.18% of 256 KB) | 881487 B (74.72% of 1152 KB)  | 102696 B (78.35% of 128 KB) |
+| **lighting-app**     | `build_tl7218x_concurrent_ota_lzma`    | 102072 B (38.94% of 256 KB) | —                        | 950564 B (80.58% of 1152 KB)  | 55360 B (21.12% of 256 KB)  |
+| **lighting-app**     | `build_tl7218x_concurrent_cs_ota_lzma` | 146248 B (55.79% of 256 KB) | —                        | 1071138 B (90.80% of 1152 KB) | 124120 B (47.35% of 256 KB) |
 
 > 📌 **Notes:**
 >
 > -   **Firmware (merged.bin)** = MCUBoot (at offset 0) + gap padding + slot0
 >     application image (`zephyr.signed.bin`). This is the file flashed to the
 >     device.
-> -   All targets fit within the slot0 partition (1152 KB) with LZMA
->     compression enabled.
+> -   All targets fit within the slot0 partition (1152 KB) with LZMA compression
+>     enabled.
 > -   The LZMA-compressed DFU image (`merged_dfu.lzma.bin`) is smaller than the
 >     signed image (e.g. 942630 B → 547530 B for TL7218X lighting).
 > -   For a detailed RAM/ROM symbol breakdown, run `west build -t ram_report` /
@@ -269,9 +269,9 @@ output (`Memory region` summary) of the build logs.
 
 📈 **Resource Usage Details**
 
-| App              | Build Target                      | RAM_ILM_N                  | ROM                           | RAM                        |
-| ---------------- | --------------------------------- | -------------------------- | ----------------------------- | -------------------------- |
-| **lighting-app** | `build_tl5218x_4m_dual_mode` | 51146 B (39.02% of 128 KB) | 935554 B (47.09% of 1940 KB)  | 87872 B (67.04% of 128 KB) |
+| App              | Build Target                 | RAM_ILM_N                  | ROM                          | RAM                        |
+| ---------------- | ---------------------------- | -------------------------- | ---------------------------- | -------------------------- |
+| **lighting-app** | `build_tl5218x_4m_dual_mode` | 51146 B (39.02% of 128 KB) | 935554 B (47.09% of 1940 KB) | 87872 B (67.04% of 128 KB) |
 
 > 📌 **Note:** TL521X currently only supports lighting-app.
 

--- a/docs/platforms/telink/releases/telink_release_notes_tl_v1.2.0-alpha-v1.5.1.0.md
+++ b/docs/platforms/telink/releases/telink_release_notes_tl_v1.2.0-alpha-v1.5.1.0.md
@@ -1,6 +1,6 @@
 # Telink Matter SDK Release Note
 
-[![Version](https://img.shields.io/badge/Version-tl_v1.2.0--alpha--v1.5.1-blue?style=flat-square)](https://github.com/telink-semi/connectedhomeip/releases/tag/tl_v1.2.0-alpha-v1.5)
+[![Version](https://img.shields.io/badge/Version-tl_v1.2.0--alpha--v1.5.1-blue?style=flat-square)](https://github.com/telink-semi/connectedhomeip/releases/tag/tl_v1.2.0-alpha-v1.5.1)
 [![License](https://img.shields.io/badge/License-Apache%202.0-red?style=flat-square)](LICENSE)
 [![Matter](https://img.shields.io/badge/Matter-v1.5-green?style=flat-square)](https://github.com/project-chip/connectedhomeip/commit/f4a8cf98ada4ad4f439b45e360800693cc5f1391)
 
@@ -10,7 +10,7 @@
 -   **Branch:**
     [pre_release-v1.2-v1.5-branch](https://github.com/telink-semi/connectedhomeip/tree/pre_release-v1.2-v1.5-branch)
 -   **Tag Version:**
-    [tl_v1.2.0-alpha-v1.5](https://github.com/telink-semi/connectedhomeip/releases/tag/tl_v1.2.0-alpha-v1.5)
+    [tl_v1.2.0-alpha-v1.5.1](https://github.com/telink-semi/connectedhomeip/releases/tag/tl_v1.2.0-alpha-v1.5.1)
 -   **Target Commit:**
     [50cae34](https://github.com/telink-semi/connectedhomeip/commit/50cae34e79ecbd5af5644eb60f6aa564f6c48ab4)
 
@@ -18,7 +18,7 @@
 
 ## 📖 Introduction
 
-This release is based on the target commit of `dev-tlk_v1.5` branch, providing
+This release is based on the latest commit of `dev-tlk_v1.5` branch, providing
 Matter protocol support for Telink RISC-V SoC platforms. It integrates the
 Matter SDK with the Telink Zephyr SDK to enable Matter-over-Thread devices on
 Telink chips including TL323X, TL521X, and TL721X.
@@ -30,7 +30,7 @@ Telink chips including TL323X, TL521X, and TL721X.
 | Category                    | Details                                                |
 | --------------------------- | ------------------------------------------------------ |
 | **Matter Support**          | Matter 1.5.1 protocol stack                            |
-| **Supported Chips**         | TL323X, TL521X, TL721X |
+| **Supported Chips** | TL323X, TL521X, TL721X |
 | **Sample Apps**             | Lighting, Light Switch, Lock, Bridge, Thermostat, etc. |
 | **OTA**                     | OTA requestor and compress-LZMA support                |
 | **Factory Data**            | Factory data provisioning support                      |
@@ -81,23 +81,27 @@ Thread network on selected Telink SoCs.
 
 | Issue             | Description                                                                   |
 | ----------------- | ----------------------------------------------------------------------------- |
+| **Network State** | Check Matter network state when power-on to ensure correct commissioning flow |
+| **TL721X HAL V2** | Update hal_v1 to hal_v2 for TL721X                                            |
+| **PM Stability**  | Improve power management stability on retention RAM configurations            |
+| **OTA Recovery**  | Fix OTA recovery flow on TL323X series                                        |
 | **Amazon Commissioning**  | Fix commissioning on Amazon when Channel Sounding is enabled          |
 
 ---
 
 ## 📦 Updates
 
--   Updated Telink BLE SDK
+-   Updated Telink BLE SDK for improved RF performance
     ([commit:53eb98b32ea79ed7ab38f5daabde0a78a7880cd9](https://github.com/telink-semi/tl_ble_sdk_zephyr/commit/53eb98b32ea79ed7ab38f5daabde0a78a7880cd9))
--   Updated Telink HAL Zephyr
-    ([commit:bdf0d7927d31809340610b5e1575667e2d862110](https://github.com/telink-semi/hal_telink/commit/bdf0d7927d31809340610b5e1575667e2d862110))
--   Updated MCUBoot
+-   Updated Telink HAL Zephyr to support TL721X
+    hal_v2([commit:bdf0d7927d31809340610b5e1575667e2d862110](https://github.com/telink-semi/hal_telink/commit/bdf0d7927d31809340610b5e1575667e2d862110))
+-   Updated MCUBoot with Telink-specific flash operation
     ([commit:ce0da85c39c749df49b0ec62b33d2ecdea24c927](https://github.com/telink-semi/mcuboot/commit/ce0da85c39c749df49b0ec62b33d2ecdea24c927))
 -   Updated OpenThread Telink source code
     ([commit:542aaab44e1308e1a8a24573dfbd413fade342ee](https://github.com/telink-semi/openthread/commit/542aaab44e1308e1a8a24573dfbd413fade342ee))
 -   Updated OpenThread Telink library
     ([commit:308dae2f80084f87073cfd4fbd30f1be0799be7b](https://github.com/telink-semi/openthread_telink_lib/commit/308dae2f80084f87073cfd4fbd30f1be0799be7b))
--   Updated Telink Zephyr SDK to support TL521X, TL323X and TL721X
+-   Updated Telink Zephyr SDK to support TL521X, TL323X and TL721X hal_v2
     ([commit:8e3ccc07900692fe5a9990cd517203de61b2eefc](https://github.com/telink-semi/zephyr/commit/8e3ccc07900692fe5a9990cd517203de61b2eefc))
 
 ---
@@ -136,7 +140,7 @@ support.
 
 | Component              | Version                                                                                                                                                                                                                                                                                   |
 | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Matter SDK Version** | Telink Matter v1.5.1.0                                                                                                                                                                                                                                                                    |
+| **Matter SDK Version** | Telink Matter v1.5.1                                                                                                                                                                                                                                                                      |
 | **Matter Branch**      | master                                                                                                                                                                                                                                                                                    |
 | **Commit**             | [f4a8cf9](https://github.com/project-chip/connectedhomeip/commit/f4a8cf98ada4ad4f439b45e360800693cc5f1391) (the previous one of [15a68d7](https://github.com/project-chip/connectedhomeip/commit/15a68d7026b1cd34a0d4cf35dadc7558e503d2cb) that community upgraded Matter version to 1.6) |
 | **Toolchain**          | Zephyr SDK v0.17.0 riscv64-zephyr-elf                                                                                                                                                                                                                                                     |
@@ -147,7 +151,7 @@ support.
 | ----------------- | --------------------------------------------------------------------------------------------------------------------- |
 | **Branch**        | [pre_release-v1.2-v1.5-branch](https://github.com/telink-semi/connectedhomeip/tree/pre_release-v1.2-v1.5-branch)      |
 | **Target Commit** | [50cae34](https://github.com/telink-semi/connectedhomeip/commit/50cae34e79ecbd5af5644eb60f6aa564f6c48ab4)                                                    |
-| **Tag Name**      | [tl_v1.2.0-alpha-v1.5](https://github.com/telink-semi/connectedhomeip/releases/tag/tl_v1.2.0-alpha-v1.5)          |
+| **Tag Name**      | [tl_v1.2.0-alpha-v1.5.1](https://github.com/telink-semi/connectedhomeip/releases/tag/tl_v1.2.0-alpha-v1.5.1)          |
 | **Release Type**  | Pre-Release (Alpha)                                                                                                   |
 
 ### Chip &amp; Hardware Versions

--- a/docs/platforms/telink/releases/telink_release_notes_tl_v1.2.0-alpha-v1.5.1.0.md
+++ b/docs/platforms/telink/releases/telink_release_notes_tl_v1.2.0-alpha-v1.5.1.0.md
@@ -27,15 +27,15 @@ Telink chips including TL323X, TL521X, and TL721X.
 
 ## ✨ Highlights
 
-| Category                    | Details                                                |
-| --------------------------- | ------------------------------------------------------ |
-| **Matter Support**          | Matter 1.5.1 protocol stack                            |
-| **Supported Chips** | TL323X, TL521X, TL721X |
-| **Sample Apps**             | Lighting, Light Switch, Lock, Bridge, Thermostat, etc. |
-| **OTA**                     | OTA requestor and compress-LZMA support                |
-| **Factory Data**            | Factory data provisioning support                      |
-| **BLE/Thread Concurrent**   | BLE + Thread concurrent mode on TL323X and TL721X      |
-| **Channel Sounding**        | CS RAS reflector support on TL721X                     |
+| Category                  | Details                                                |
+| ------------------------- | ------------------------------------------------------ |
+| **Matter Support**        | Matter 1.5.1 protocol stack                            |
+| **Supported Chips**       | TL323X, TL521X, TL721X                                 |
+| **Sample Apps**           | Lighting, Light Switch, Lock, Bridge, Thermostat, etc. |
+| **OTA**                   | OTA requestor and compress-LZMA support                |
+| **Factory Data**          | Factory data provisioning support                      |
+| **BLE/Thread Concurrent** | BLE + Thread concurrent mode on TL323X and TL721X      |
+| **Channel Sounding**      | CS RAS reflector support on TL721X                     |
 
 ---
 
@@ -68,7 +68,7 @@ Thread network on selected Telink SoCs.
 | SoC Family | BLE-Only | Thread-Only | BLE + Thread Concurrent | Channel Sounding |
 | :--------: | :------: | :---------: | :---------------------: | :--------------: |
 |   TL323X   |    ✅    |     ✅      |           ✅            |        —         |
-|   TL521X   |    ✅    |     ✅      |           —             |        —         |
+|   TL521X   |    ✅    |     ✅      |            —            |        —         |
 |   TL721X   |    ✅    |     ✅      |           ✅            |        ✅        |
 
 > **Note:** BLE + Thread concurrent mode requires the `*_concurrent` board
@@ -79,13 +79,13 @@ Thread network on selected Telink SoCs.
 
 ## 🐛 Bug Fixes
 
-| Issue             | Description                                                                   |
-| ----------------- | ----------------------------------------------------------------------------- |
-| **Network State** | Check Matter network state when power-on to ensure correct commissioning flow |
-| **TL721X HAL V2** | Update hal_v1 to hal_v2 for TL721X                                            |
-| **PM Stability**  | Improve power management stability on retention RAM configurations            |
-| **OTA Recovery**  | Fix OTA recovery flow on TL323X series                                        |
-| **Amazon Commissioning**  | Fix commissioning on Amazon when Channel Sounding is enabled          |
+| Issue                    | Description                                                                   |
+| ------------------------ | ----------------------------------------------------------------------------- |
+| **Network State**        | Check Matter network state when power-on to ensure correct commissioning flow |
+| **TL721X HAL V2**        | Update hal_v1 to hal_v2 for TL721X                                            |
+| **PM Stability**         | Improve power management stability on retention RAM configurations            |
+| **OTA Recovery**         | Fix OTA recovery flow on TL323X series                                        |
+| **Amazon Commissioning** | Fix commissioning on Amazon when Channel Sounding is enabled                  |
 
 ---
 
@@ -147,12 +147,12 @@ support.
 
 ### Telink Matter SDK
 
-| Property          | Version                                                                                                               |
-| ----------------- | --------------------------------------------------------------------------------------------------------------------- |
-| **Branch**        | [pre_release-v1.2-v1.5-branch](https://github.com/telink-semi/connectedhomeip/tree/pre_release-v1.2-v1.5-branch)      |
-| **Target Commit** | [50cae34](https://github.com/telink-semi/connectedhomeip/commit/50cae34e79ecbd5af5644eb60f6aa564f6c48ab4)                                                    |
-| **Tag Name**      | [tl_v1.2.0-alpha-v1.5.1](https://github.com/telink-semi/connectedhomeip/releases/tag/tl_v1.2.0-alpha-v1.5.1)          |
-| **Release Type**  | Pre-Release (Alpha)                                                                                                   |
+| Property          | Version                                                                                                          |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------- |
+| **Branch**        | [pre_release-v1.2-v1.5-branch](https://github.com/telink-semi/connectedhomeip/tree/pre_release-v1.2-v1.5-branch) |
+| **Target Commit** | [50cae34](https://github.com/telink-semi/connectedhomeip/commit/50cae34e79ecbd5af5644eb60f6aa564f6c48ab4)        |
+| **Tag Name**      | [tl_v1.2.0-alpha-v1.5.1](https://github.com/telink-semi/connectedhomeip/releases/tag/tl_v1.2.0-alpha-v1.5.1)     |
+| **Release Type**  | Pre-Release (Alpha)                                                                                              |
 
 ### Chip &amp; Hardware Versions
 
@@ -199,9 +199,9 @@ example and the Telink chip platforms that support it (see
 -   **Supported but untested (🟡):** TL721X bridge-app and window-app are
     compiled successfully but have not been functionally validated.
 -   **Untested (·):** Combinations not listed are not built or validated.
--   TL323X / TL521X / TL721X are the latest Telink RISC-V SoC families.
-    Lighting and light-switch apps are supported across TL323X and TL721X;
-    TL521X supports lighting-app only.
+-   TL323X / TL521X / TL721X are the latest Telink RISC-V SoC families. Lighting
+    and light-switch apps are supported across TL323X and TL721X; TL521X
+    supports lighting-app only.
 -   The light-switch-app uses the `*_retention` board target (power management
     with retention RAM).
 -   For build commands per board/app, refer to the per-board `*_README.md` files
@@ -216,11 +216,11 @@ platforms, built with the Matter SDK and Zephyr RTOS.
 
 ### Supported Boards
 
-| Board    | Chip Family |
-| -------- | ----------- |
-| tl3238x  | TL323X      |
-| tl5218x  | TL521X      |
-| tl7218x  | TL721X      |
+| Board   | Chip Family |
+| ------- | ----------- |
+| tl3238x | TL323X      |
+| tl5218x | TL521X      |
+| tl7218x | TL721X      |
 
 ### TL323X/TL721X Matter (OTA + LZMA) Code Size
 
@@ -238,30 +238,30 @@ output (`Memory region` summary) of the build logs.
 
 📈 **Resource Usage Details**
 
-| App                  | Build Target                              | RAM_ILM_N                 | ROM                          | RAM                       |
-| -------------------- | ----------------------------------------- | ------------------------- | ---------------------------- | ------------------------- |
-| **lighting-app**     | `build_tl3238x_2m_flash_lzma`             | 54006 B (82.41% of 64 KB) | 960074 B (81.39% of 1152 KB) | 90464 B (92.02% of 96 KB) |
-| **light-switch-app** | `build_tl3238x_retention_lzma`            | 63734 B (97.25% of 64 KB) | 904554 B (76.68% of 1152 KB) | 84496 B (85.95% of 96 KB) |
-| **lighting-app**     | `build_tl3238x_concurrent_ota_lzma`       | 60168 B (91.81% of 64 KB) | 960080 B (81.39% of 1152 KB) | 90448 B (92.01% of 96 KB) |
+| App                  | Build Target                        | RAM_ILM_N                 | ROM                          | RAM                       |
+| -------------------- | ----------------------------------- | ------------------------- | ---------------------------- | ------------------------- |
+| **lighting-app**     | `build_tl3238x_2m_flash_lzma`       | 54006 B (82.41% of 64 KB) | 960074 B (81.39% of 1152 KB) | 90464 B (92.02% of 96 KB) |
+| **light-switch-app** | `build_tl3238x_retention_lzma`      | 63734 B (97.25% of 64 KB) | 904554 B (76.68% of 1152 KB) | 84496 B (85.95% of 96 KB) |
+| **lighting-app**     | `build_tl3238x_concurrent_ota_lzma` | 60168 B (91.81% of 64 KB) | 960080 B (81.39% of 1152 KB) | 90448 B (92.01% of 96 KB) |
 
 #### TL721X (tl7218x)
 
 📈 **Resource Usage Details**
 
-| App                  | Build Target                                  | RAMILM / RAM_ILM_N         | RAM_DLM                   | ROM                          | RAM                         |
-| -------------------- | --------------------------------------------- | -------------------------- | ------------------------- | ---------------------------- | --------------------------- |
-| **lighting-app**     | `build_tl7218x_lzma`                   | 93376 B (35.62% of 256 KB) | —                         | 938542 B (79.56% of 1152 KB) | 55200 B (21.06% of 256 KB)  |
-| **light-switch-app** | `build_tl7218x_retention_lzma`         | 47098 B (35.93% of 128 KB) | 8346 B (3.18% of 256 KB)  | 881487 B (74.72% of 1152 KB) | 102696 B (78.35% of 128 KB) |
-| **lighting-app**     | `build_tl7218x_concurrent_ota_lzma`    | 102072 B (38.94% of 256 KB) | —                        | 950564 B (80.58% of 1152 KB) | 55360 B (21.12% of 256 KB)  |
-| **lighting-app**     | `build_tl7218x_concurrent_cs_ota_lzma` | 146248 B (55.79% of 256 KB) | —                   | 1071138 B (90.80% of 1152 KB) | 124120 B (47.35% of 256 KB) |
+| App                  | Build Target                           | RAMILM / RAM_ILM_N          | RAM_DLM                  | ROM                           | RAM                         |
+| -------------------- | -------------------------------------- | --------------------------- | ------------------------ | ----------------------------- | --------------------------- |
+| **lighting-app**     | `build_tl7218x_lzma`                   | 93376 B (35.62% of 256 KB)  | —                        | 938542 B (79.56% of 1152 KB)  | 55200 B (21.06% of 256 KB)  |
+| **light-switch-app** | `build_tl7218x_retention_lzma`         | 47098 B (35.93% of 128 KB)  | 8346 B (3.18% of 256 KB) | 881487 B (74.72% of 1152 KB)  | 102696 B (78.35% of 128 KB) |
+| **lighting-app**     | `build_tl7218x_concurrent_ota_lzma`    | 102072 B (38.94% of 256 KB) | —                        | 950564 B (80.58% of 1152 KB)  | 55360 B (21.12% of 256 KB)  |
+| **lighting-app**     | `build_tl7218x_concurrent_cs_ota_lzma` | 146248 B (55.79% of 256 KB) | —                        | 1071138 B (90.80% of 1152 KB) | 124120 B (47.35% of 256 KB) |
 
 > 📌 **Notes:**
 >
 > -   **Firmware (merged.bin)** = MCUBoot (at offset 0) + gap padding + slot0
 >     application image (`zephyr.signed.bin`). This is the file flashed to the
 >     device.
-> -   All targets fit within the slot0 partition (1152 KB) with LZMA
->     compression enabled.
+> -   All targets fit within the slot0 partition (1152 KB) with LZMA compression
+>     enabled.
 > -   The LZMA-compressed DFU image (`merged_dfu.lzma.bin`) is smaller than the
 >     signed image (e.g. 942630 B → 547530 B for TL7218X lighting).
 > -   For a detailed RAM/ROM symbol breakdown, run `west build -t ram_report` /
@@ -273,9 +273,9 @@ output (`Memory region` summary) of the build logs.
 
 📈 **Resource Usage Details**
 
-| App              | Build Target                      | RAM_ILM_N                  | ROM                           | RAM                        |
-| ---------------- | --------------------------------- | -------------------------- | ----------------------------- | -------------------------- |
-| **lighting-app** | `build_tl5218x_4m_dual_mode` | 51146 B (39.02% of 128 KB) | 935554 B (47.09% of 1940 KB)  | 87872 B (67.04% of 128 KB) |
+| App              | Build Target                 | RAM_ILM_N                  | ROM                          | RAM                        |
+| ---------------- | ---------------------------- | -------------------------- | ---------------------------- | -------------------------- |
+| **lighting-app** | `build_tl5218x_4m_dual_mode` | 51146 B (39.02% of 128 KB) | 935554 B (47.09% of 1940 KB) | 87872 B (67.04% of 128 KB) |
 
 > 📌 **Note:** TL521X currently only supports lighting-app.
 


### PR DESCRIPTION
#### Summary

This PR updates the Telink Matter v1.2.0-alpha release documentation with the
latest firmware build data and adds support for new platforms and build
configurations:

- **TL323X**: Update lighting-app and light-switch-app resource usage data from
  the latest builds; add BLE + Thread concurrent mode target
- **TL721X**: Update lighting-app and light-switch-app data; add BLE + Thread
  concurrent mode and concurrent + Channel Sounding targets
- **TL521X**: Replace placeholder with real build data for lighting-app on 4 MB
  Flash with dual-mode configuration

Additionally, this PR trims the release notes and related documentation to focus
on the latest SoC families (TL323X, TL521X, TL721X):

- `docs/platforms/telink/releases/telink_release_notes.md`
- `docs/platforms/telink/releases/telink_release_notes_tl_v1.2.0-alpha-v1.5.1.0.md`
- `README.md`
- `docs/platforms/telink/releases/README_BUILD_SCRIPT.md`

Finally, renames `build_and_update_matter_notes.py` to
`generate_and_update_matter_notes.py` and updates all references accordingly.

#### Related issues

N/A

#### Testing

All resource usage data was obtained by manually building each firmware target
with `west build` on a Telink Zephyr SDK v0.17.0 environment. The `Memory
region` output from each build log was copied directly into the release notes
tables.

#### Readability checklist

- [x] PR title is `[telink] ...` following the format convention
- [x] Apply the coding style guideline
- [x] PR size is short
- [x] Try to avoid "squashing" and "force-update" in commit history
- [x] CI time didn't increase