### PR TITLE
Telink: Fix sync release docs to dev

### DIFF
--- a/docs/platforms/telink/releases/telink_release_notes.md
+++ b/docs/platforms/telink/releases/telink_release_notes.md
@@ -156,7 +156,7 @@ support.
 
 | Chip Family | Versions |
 | ----------- | -------- |
-| TL323X      | A0       |
+| TL323X      | A0/A1    |
 | TL521X      | A0       |
 | TL721X      | A2/A3    |
 

--- a/docs/platforms/telink/releases/telink_release_notes_tl_v1.0.1-beta-v1.5.1.0.md
+++ b/docs/platforms/telink/releases/telink_release_notes_tl_v1.0.1-beta-v1.5.1.0.md
@@ -138,7 +138,7 @@ support.
 | TLSR911X(W91)          | A2       |
 | TL721X                 | A2/A3    |
 | TL321X                 | A1/A2/A3 |
-| TL323X                 | A0       |
+| TL323X                 | A0/A1    |
 
 🔧 **Hardware EVK Versions**
 

--- a/docs/platforms/telink/releases/telink_release_notes_tl_v1.0.1-rc1-v1.5.1.0.md
+++ b/docs/platforms/telink/releases/telink_release_notes_tl_v1.0.1-rc1-v1.5.1.0.md
@@ -1,0 +1,345 @@
+# Telink Matter SDK Release Note
+
+[![Version](https://img.shields.io/badge/Version-tl_v1.0.1--rc1--v1.5-blue?style=flat-square)](https://github.com/telink-semi/connectedhomeip/releases/tag/tl_v1.0.1-rc1-v1.5)
+[![License](https://img.shields.io/badge/License-Apache%202.0-red?style=flat-square)](LICENSE)
+[![Matter](https://img.shields.io/badge/Matter-v1.5-green?style=flat-square)](https://github.com/project-chip/connectedhomeip/commit/f4a8cf98ada4ad4f439b45e360800693cc5f1391)
+
+---
+
+-   **Release Type:** Pre-Release (rc1)
+-   **Branch:**
+    [release-v1.0-v1.5-branch](https://github.com/telink-semi/connectedhomeip/tree/release-v1.0-v1.5-branch)
+-   **Tag Version:**
+    [tl_v1.0.1-rc1-v1.5](https://github.com/telink-semi/connectedhomeip/releases/tag/tl_v1.0.1-rc1-v1.5)
+    <!-- -   **Target Commit:**
+        [b4c04e3](https://github.com/telink-semi/connectedhomeip/commit/b4c04e3c1816fc242a100e305047ac1350457d17) -->
+
+---
+
+## 📖 Introduction
+
+<!-- This release is based on the latest commit of `release-v1.0-v1.5-branch` branch,
+providing Matter protocol support for Telink RISC-V SoC platforms. It integrates
+the Matter SDK with the Telink Zephyr SDK to enable Matter-over-Thread devices
+on Telink chips including TLSR9 Series, TL321X, TL323X, and TL721X. -->
+
+This release is based on the latest commit of `release-v1.0-v1.5-branch` branch,
+providing Matter protocol support for Telink RISC-V SoC platforms. It integrates
+the Matter SDK with the Telink Zephyr SDK to enable Matter-over-Thread devices
+on Telink chips including TL323X and TL721X.
+
+---
+
+## 📋 Version Information
+
+### Matter SDK &amp; Toolchain
+
+| Component              | Version                                                                                                                                                                                                                                                                                   |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Matter SDK Version** | Telink Matter v1.5                                                                                                                                                                                                                                                                        |
+| **Matter Branch**      | master                                                                                                                                                                                                                                                                                    |
+| **Commit**             | [f4a8cf9](https://github.com/project-chip/connectedhomeip/commit/f4a8cf98ada4ad4f439b45e360800693cc5f1391) (the previous one of [15a68d7](https://github.com/project-chip/connectedhomeip/commit/15a68d7026b1cd34a0d4cf35dadc7558e503d2cb) that community upgraded Matter version to 1.6) |
+| **Toolchain**          | Zephyr SDK v0.17.0 riscv64-zephyr-elf                                                                                                                                                                                                                                                     |
+
+### Telink Matter SDK
+
+<!-- | Property          | Version                                                                                                      |
+| ----------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Branch**        | [release-v1.0-v1.5-branch](https://github.com/telink-semi/connectedhomeip/tree/release-v1.0-v1.5-branch)     |
+| **Target Commit** | [b4c04e3](https://github.com/telink-semi/connectedhomeip/commit/b4c04e3c1816fc242a100e305047ac1350457d17)    |
+| **Tag Name**      | [tl_v1.0.1-rc1-v1.5](https://github.com/telink-semi/connectedhomeip/releases/tag/tl_v1.0.1-rc1-v1.5) |
+| **Release Type**  | Pre-Release (rc1)                                                                                            | -->
+
+| Property         | Version                                                                                                  |
+| ---------------- | -------------------------------------------------------------------------------------------------------- |
+| **Branch**       | [release-v1.0-v1.5-branch](https://github.com/telink-semi/connectedhomeip/tree/release-v1.0-v1.5-branch) |
+| **Tag Name**     | [tl_v1.0.1-rc1-v1.5](https://github.com/telink-semi/connectedhomeip/releases/tag/tl_v1.0.1-rc1-v1.5)     |
+| **Release Type** | Pre-Release (rc1)                                                                                        |
+
+### Chip &amp; Hardware Versions
+
+📦 **Chip Versions**
+
+<!-- | Chip Family            | Versions |
+| ---------------------- | -------- |
+| TLSR921X/TLSR951X(B91) | A2       |
+| TLSR922X/TLSR952X(B92) | A3/A4    |
+| TLSR911X(W91)          | A2       |
+| TL721X                 | A2/A3    |
+| TL321X                 | A1/A2/A3 |
+| TL323X                 | A0/A1    | -->
+
+| Chip Family | Versions |
+| ----------- | -------- |
+| TL721X      | A2/A3    |
+| TL323X      | A0/A1    |
+
+🔧 **Hardware EVK Versions**
+
+<!-- | Chip     | EVK Version                   |
+| -------- | ----------------------------- |
+| TLSR921X | C1T213A20_V1.3                |
+| TLSR952X | C1T266A20_V1.3                |
+| TLSR911X | C1T301A20_V2.1                |
+| TL721X   | C1T315A20_V1.2                |
+| TL321X   | C1T331A20_V1.0/C1T335A20_V1.3 |
+| TL323X   | C1T388A20_V1.1                | -->
+
+| Chip   | EVK Version    |
+| ------ | -------------- |
+| TL721X | C1T315A20_V1.2 |
+| TL323X | C1T388A20_V1.1 |
+
+---
+
+## ✨ Highlights
+
+<!-- | Category            | Details                                                |
+| ------------------- | ------------------------------------------------------ |
+| **Matter Support**  | Matter 1.5.1 protocol stack                            |
+| **Supported Chips** | TLSR951X, TLSR952X, TLSR911X, TL321X, TL323X, TL721X   |
+| **Sample Apps**     | Lighting, Light Switch, Lock, Bridge, Thermostat, etc. |
+| **OTA**             | OTA requestor and compress-LZMA support                |
+| **Factory Data**    | Factory data provisioning support                      | -->
+
+| Category            | Details                                              |
+| ------------------- | ---------------------------------------------------- |
+| **Matter Support**  | Matter 1.5                                           |
+| **Supported Chips** | TL323X, TL721X                                       |
+| **Sample Apps**     | Lighting, Light Switch, window, contact sensor, etc. |
+| **OTA**             | OTA requestor and compress-LZMA support              |
+| **Factory Data**    | Factory data provisioning support                    |
+
+---
+
+## 🆕 New Features
+
+-   ✅ Matter 1.5 support for Telink platforms
+-   ✅ Full support for TL323X series chips in Matter
+-   ✅ Support for TL721X series chips in Matter
+-   ✅ LZMA compression support for OTA images
+-   ✅ Factory data provisioning support
+-   ✅ Dual-mode configuration support for TL3238X
+-   ✅ Power management with retention RAM support
+-   ✅ NFC payload support for all-clusters-minimal-app
+-   ✅ DFU over SMP support for lock-app
+
+---
+
+## 🐛 Bug Fixes
+
+| Issue             | Description                                                                   |
+| ----------------- | ----------------------------------------------------------------------------- |
+| **Network State** | Check Matter network state when power-on to ensure correct commissioning flow |
+| **TL721X HAL V2** | Update hal_v1 to hal_v2 for TL721X                                            |
+| **PM Stability**  | Improve power management stability on retention RAM configurations            |
+| **OTA Recovery**  | Fix OTA recovery flow on TL323X series                                        |
+
+---
+
+## 📦 Updates / Dependencies
+
+| Component                 | Repository                                                                                | Commit                                                                                                            | Notes                                                                                                             |
+| ------------------------- | ----------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| **Telink BLE SDK**        | [telink-semi/tl_ble_sdk_zephyr](https://github.com/telink-semi/tl_ble_sdk_zephyr)         | [`46322e5`](https://github.com/telink-semi/tl_ble_sdk_zephyr/commit/46322e5b570e2a68373b18d4f08811acadd1266c)     | Required by all Telink SoCs; fetch via `./hal_v2/fetch_sdk.sh` (hal_v2) or `west blobs fetch hal_telink` (hal_v1) |
+| **Telink HAL Zephyr**     | [telink-semi/hal_telink](https://github.com/telink-semi/hal_telink)                       | [`14c6149`](https://github.com/telink-semi/hal_telink/commit/14c6149f6cc466c49d81e3b2f7f1e4d8ff6fbbb5)            | Contains both hal_v1 and hal_v2 sources                                                                           |
+| **MCUBoot**               | [telink-semi/mcuboot](https://github.com/telink-semi/mcuboot)                             | [`ce0da85`](https://github.com/telink-semi/mcuboot/commit/ce0da85c39c749df49b0ec62b33d2ecdea24c927)               | Bootloader; required for OTA/DFU                                                                                  |
+| **OpenThread Telink**     | [telink-semi/openthread](https://github.com/telink-semi/openthread)                       | [`542aaab`](https://github.com/telink-semi/openthread/commit/542aaab44e1308e1a8a24573dfbd413fade342ee)            | OpenThread source adapted for Telink                                                                              |
+| **OpenThread Telink Lib** | [telink-semi/openthread_telink_lib](https://github.com/telink-semi/openthread_telink_lib) | [`308dae2`](https://github.com/telink-semi/openthread_telink_lib/commit/308dae2f80084f87073cfd4fbd30f1be0799be7b) | Pre-built OpenThread library for Telink                                                                           |
+| **Telink Zephyr SDK**     | [telink-semi/zephyr](https://github.com/telink-semi/zephyr)                               | [`7b102df`](https://github.com/telink-semi/zephyr/commit/7b102dfc9bc4c27e95dc84bd6291caf46b6b070c)                | Telink Zephyr SDK; supports TL323X and TL721X hal_v2                                                              |
+
+---
+
+## ⚠️ Important Notes
+
+**This is a pre-release version for demonstration, development and testing
+purposes. Not recommended for production use.**
+
+### Telink Matter ↔ Telink Zephyr Dependency
+
+The Telink Matter SDK is built **on top of** the Telink Zephyr SDK, and the two
+are tightly coupled — they must be used as a matched pair.
+
+The Telink Zephyr SDK provides the foundational layers required to bring up a
+Matter device on Telink silicon: the Zephyr RTOS core, the Telink hardware
+abstraction layer (HAL), the BLE stack, MCUBoot bootloader, OpenThread
+networking stack, the WEST tool and build toolchain.
+
+The Telink Matter SDK (this repository) builds upon that foundation to deliver
+the Matter protocol stack itself together with a set of Telink Matter example
+applications. Both components are required: the Matter SDK cannot be built
+without the Zephyr SDK, and the Zephyr SDK alone does not provide Matter
+support.
+
+> ⚠️ **Version pairing:** This Telink Matter release is validated against a
+> specific Telink Zephyr SDK tag (see the
+> [Version Information](#version-information) table below). Using a different
+> Zephyr revision may cause build failures or runtime issues.
+
+---
+
+## 📱 Matter Community Examples
+
+This release provides Telink platform ports for the following Matter community
+example applications. Each example is located under
+`examples/<app-name>/telink/` in the repository. The table below summarizes each
+example and the Telink chip platforms that support it (see
+[Telink Examples YAML file](.github/workflows/examples-telink.yaml)).
+
+> ✅ = Supported and Tested &nbsp;&nbsp; 🟡 = Supported but Untested
+> &nbsp;&nbsp; · = Untested
+
+<!-- | Example                  | Description                                                | B91 (TLSR951X) | B92 (TLSR952X) | W91 (TLSR911X) | TL321X | TL323X | TL721X |
+| ------------------------ | ---------------------------------------------------------- | :------------: | :------------: | :------------: | :----: | :----: | :----: |
+| lighting-app             | Lighting (On/Off, Level, Color Control)                    |       🟡       |       ·        |       🟡       |   🟡   |   ✅   |   ✅   |
+| light-switch-app         | Light Switch (controller, switches a bound lighting-app)   |       ·        |       🟡       |       ·        |   🟡   |   ✅   |   ✅   |
+| bridge-app               | Bridge / Aggregator (bridges non-Matter devices to Matter) |       ·        |       ·        |       ·        |   ·    |   ·    |   🟡   |
+| window-app               | Window Covering (shades, blinds)                           |       ·        |       ·        |       ·        |   ·    |   ·    |   🟡   |
+| air-quality-sensor-app   | Air Quality Sensor                                         |       ·        |       🟡       |       ·        |   ·    |   ·    |   ·    |
+| all-clusters-app         | All Clusters (full-featured test app)                      |       ·        |       ·        |       🟡       |   ·    |   ·    |   ·    |
+| all-clusters-minimal-app | All Clusters Minimal (lightweight test app, NFC payload)   |       ·        |       🟡       |       ·        |   ·    |   ·    |   ·    |
+| contact-sensor-app       | Contact Sensor (stateless contact sensing)                 |       ·        |       🟡       |       ·        |   ·    |   ·    |   ·    |
+| lock-app                 | Door Lock (supports DFU over BLE SMP)                      |       ·        |       🟡       |       ·        |   ·    |   ·    |   ·    |
+| smoke-co-alarm-app       | Smoke &amp; CO Alarm                                       |       ·        |       🟡       |       ·        |   ·    |   ·    |   ·    |
+| pump-controller-app      | Pump Controller                                            |       🟡       |       ·        |       ·        |   ·    |   ·    |   ·    |
+| shell                    | Shell (debug console)                                      |       🟡       |       ·        |       ·        |   ·    |   ·    |   ·    |
+| thermostat               | Thermostat                                                 |       ·        |       ·        |       🟡       |   ·    |   ·    |   ·    |
+| ota-requestor-app        | OTA Requestor (handles OTA image download)                 |       ·        |       ·        |       ·        |   🟡   |   ·    |   ·    | -->
+
+| Example            | Description                                              | TL323X | TL721X |
+| ------------------ | -------------------------------------------------------- | :----: | :----: |
+| lighting-app       | Lighting (On/Off, Level, Color Control)                  |   ✅   |   ✅   |
+| light-switch-app   | Light Switch (controller, switches a bound lighting-app) |   ✅   |   ✅   |
+| window-app         | Window Covering (shades, blinds)                         |   ·    |   🟡   |
+| contact-sensor-app | Contact Sensor (stateless contact sensing)               |   ·    |   ·    |
+| lock-app           | Door Lock (supports DFU over BLE SMP)                    |   ·    |   ·    |
+
+<!-- To do: lit more examples to test and tag the timeframe -->
+
+### Notes on Platform Support
+
+<!-- -   **Tested combinations (✅):** Only TL323X and TL721X with lighting-app and
+    light-switch-app have been fully tested in this release.
+-   **Supported but untested (🟡):** All other build targets listed in the table
+    are compiled successfully but have not been functionally validated in this
+    release. Use with caution.
+-   **Untested (·):** Combinations not listed are not built or validated in this
+    release.
+-   **B91 (TLSR951X)** and **W91 (TLSR911X)** are legacy platforms with broad
+    sample coverage (lighting, pump-controller, shell, thermostat,
+    all-clusters).
+-   **B92 (TLSR952X)** targets sensors and small appliances (air-quality,
+    contact-sensor, smoke-co-alarm, lock, light-switch, all-clusters-minimal).
+-   **TL321X / TL323X / TL721X** are the latest Telink RISC-V SoC families.
+    Lighting and light-switch apps are supported across all three; TL721X
+    additionally supports bridge-app and window-app.
+-   The light-switch-app on TL321X/TL323X/TL721X uses the `*_retention` board
+    target (power management with retention RAM).
+-   For build commands per board/app, refer to the per-board `*_README.md` files
+    inside each example's `boards/` directory. -->
+
+-   **Tested combinations (✅):** Only TL323X and TL721X with lighting-app and
+    light-switch-app have been fully tested in this release.
+-   **Supported but untested (🟡):** All other build targets listed in the table
+    are compiled successfully but have not been functionally validated in this
+    release. Use with caution.
+-   **Untested (·):** Combinations not listed are not built or validated in this
+    release.
+-   **TL323X / TL721X** are the latest Telink RISC-V SoC families. Lighting and
+    light-switch apps are supported across all three; TL721X additionally
+    supports bridge-app and window-app.
+-   The light-switch-app on TL323X/TL721X uses the `*_retention` board target
+    (power management with retention RAM).
+-   For build commands per board/app, refer to the per-board `*_README.md` files
+    inside each example's `boards/` directory.
+
+---
+
+## 📊 Resource Usage (Code Size)
+
+This section shows the RAM and ROM usage for various Matter examples on Telink
+platforms, built with the Matter SDK and Zephyr RTOS.
+
+### Supported Boards
+
+<!-- | Board          | Chip Family  |
+| -------------- | ------------ |
+| tlsr9518adk80d | TLSR951X/B91 |
+| tlsr9528a      | TLSR952X/B92 |
+| tl3218x        | TL321X       |
+| tl3238x        | TL323X       |
+| tl7218x        | TL721X       |
+| tlsr9118bdk40d | TLSR911X/W91 | -->
+
+<!-- | Board          | Chip Family  |
+| -------------- | ------------ |
+| tl3238x        | TL323X       |
+| tl7218x        | TL721X       | -->
+
+### TL323X/TL721X Matter (OTA + LZMA) Code Size
+
+The tables below list the **Supported and Tested** Matter build targets for
+TL323X and TL721X, built with OTA + BT DFU + LZMA compression enabled (2MB
+Flash, Software Version 1). Memory usage data is extracted from the linker
+output (`Memory region` summary) of the build logs.
+
+> 📌 **Memory Regions:** TL323X exposes `RAM_ILM_N` (instruction RAM, 64 KB) +
+> `RAM` (data RAM, 96 KB); TL7218X exposes `RAMILM` (unified, 256 KB) or
+> `RAM_ILM_N` (128 KB) + `RAM_DLM` (256 KB) depending on the board target. `ROM`
+> is the application slot0 partition (1152 KB with LZMA overlay).
+
+#### TL323X (tl3238x)
+
+📈 **Resource Usage Details**
+
+| App                  | Build Target                      | RAM_ILM_N                 | ROM                          | RAM                       | Firmware (merged.bin) |
+| -------------------- | --------------------------------- | ------------------------- | ---------------------------- | ------------------------- | --------------------- |
+| **lighting-app**     | `build_tl3238x_2m_flash_lzma_v1`  | 51788 B (79.02% of 64 KB) | 960663 B (81.44% of 1152 KB) | 92552 B (94.15% of 96 KB) | 1047015 B             |
+| **light-switch-app** | `build_tl3238x_retention_lzma_v1` | 61558 B (93.93% of 64 KB) | 905054 B (76.72% of 1152 KB) | 86608 B (88.10% of 96 KB) | 991406 B              |
+
+#### TL721X (tl7218x)
+
+📈 **Resource Usage Details**
+
+| App                  | Build Target                      | RAMILM / RAM_ILM_N         | RAM_DLM                   | ROM                          | RAM                         | Firmware (merged.bin) |
+| -------------------- | --------------------------------- | -------------------------- | ------------------------- | ---------------------------- | --------------------------- | --------------------- |
+| **lighting-app**     | `build_tl7218x_2m_flash_lzma_v1`  | 96432 B (36.79% of 256 KB) | —                         | 942294 B (79.88% of 1152 KB) | 55936 B (21.34% of 256 KB)  | 1028646 B             |
+| **light-switch-app** | `build_tl7218x_retention_lzma_v1` | 46834 B (35.73% of 128 KB) | 10026 B (3.82% of 256 KB) | 886204 B (75.12% of 1152 KB) | 104616 B (79.82% of 128 KB) | 972556 B              |
+
+> 📌 **Notes:**
+>
+> -   **Firmware (merged.bin)** = MCUBoot (at offset 0) + gap padding + slot0
+>     application image (`zephyr.signed.bin`). This is the file flashed to the
+>     device.
+> -   All four targets fit within the slot0 partition (1152 KB) with LZMA
+>     compression enabled.
+> -   The LZMA-compressed DFU image (`merged_dfu.lzma.bin`) is smaller than the
+>     signed image (e.g. 942630 B → 547530 B for TL7218X lighting).
+
+<!-- > -   For a detailed RAM/ROM symbol breakdown, run `west build -t ram_report` /
+>     `west build -t rom_report` in the build directory. -->
+
+---
+
+### 📝 Additional Notes
+
+-   **Memory Regions:** May vary between chip variants; check individual board
+    configurations
+-   **Build Config:** Matter builds use `west build` directly from each
+    example's `telink` directory; CI builds use the Matter `build_examples.py`
+    system with Telink targets
+-   **Production Optimizations:** For production builds, preform further
+    develop, disable debug logging and enable appropriate optimizations to
+    reduce RAM/ROM usage
+-   **Bluetooth &amp; OpenThread:** Matter uses OpenThread for Thread networking
+    and BLE for commissioning
+-   **OTA Images:** Signed OTA images (`zephyr.signed.bin`) are generated when
+    OTA is enabled
+
+---
+
+Made by Telink Semiconductor
+
+-   [Website](https://www.telink-semi.com/)
+-   [Forum](https://forum.telink-semi.cn/)
+-   [Documentation](https://doc.telink-semi.cn/)

--- a/docs/platforms/telink/releases/telink_release_notes_tl_v1.2.0-alpha-v1.5.1.0.md
+++ b/docs/platforms/telink/releases/telink_release_notes_tl_v1.2.0-alpha-v1.5.1.0.md
@@ -160,7 +160,7 @@ support.
 
 | Chip Family | Versions |
 | ----------- | -------- |
-| TL323X      | A0       |
+| TL323X      | A0/A1    |
 | TL521X      | A0       |
 | TL721X      | A2/A3    |
 

--- a/docs/platforms/telink/telink_getting_started.md
+++ b/docs/platforms/telink/telink_getting_started.md
@@ -6,16 +6,20 @@ platforms.
 
 ## Prerequisites
 
-### Supported Chips and Boards
+### Chip and Board used in the guide
 
-| Board target     | Chip Family    | Flash (default) | Notes                                 |
+<!-- | Board target     | Chip Family    | Flash (default) | Notes                                 |
 | ---------------- | -------------- | :-------------: | ------------------------------------- |
 | `tlsr9518adk80d` | TLSR951X / B91 |      2 MB       | Legacy; broad sample coverage         |
 | `tlsr9528a`      | TLSR952X / B92 |      2 MB       | `_retention` variant for low-power    |
 | `tlsr9118bdk40d` | TLSR911X / W91 |      2 MB       | Legacy; broad sample coverage         |
 | `tl3218x`        | TL321X         |      2 MB       | `_retention` variant for low-power    |
 | `tl3238x`        | TL323X         |      2 MB       | Dual-mode (Matter + Zigbee) supported |
-| `tl7218x`        | TL721X         |      2 MB       | `_retention` variant for low-power    |
+| `tl7218x`        | TL721X         |      2 MB       | `_retention` variant for low-power    | -->
+
+| Board target | Chip Family | EVK Version    | Flash (default) | Notes                                 |
+| ------------ | ----------- | -------------- | :-------------: | ------------------------------------- |
+| `tl3238x`    | TL323X      | C1T388A20_V1.1 |      2 MB       | Dual-mode (Matter + Zigbee) supported |
 
 > See the [Release Notes](./releases/telink_release_notes.md) for the exact chip
 > versions, EVK versions, and per-example support matrix validated in each
@@ -102,7 +106,7 @@ source ~/.bashrc
 
 ### 1.6 (hal_v2 chips only) Fetch the TL323X BLE SDK
 
-For **TL322X / TL323X** (hal_v2) chips, additionally fetch the BLE SDK:
+For **TL323X** (hal_v2) chips, additionally fetch the BLE SDK:
 
 ```bash
 cd ~/zephyrproject/modules/hal/telink/hal_v2
@@ -120,7 +124,7 @@ west build -p auto -b tlsr9518adk80d zephyr/samples/hello_world -d build_helloWo
 ```
 
 For more details, see the
-[Telink Zephyr Getting Started guide](https://github.com/telink-semi/zephyr/blob/develop/doc/telink/getting_started/index.md).
+[Telink Zephyr Getting Started guide](https://github.com/telink-semi/zephyr/blob/release-v1.0-v4.1-branch/doc/telink/getting_started/index.md).
 
 ## Step 2: Get the Matter source code
 
@@ -137,7 +141,7 @@ sudo apt-get install git gcc g++ pkg-config libssl-dev libdbus-1-dev \
 ```bash
 git clone https://github.com/telink-semi/connectedhomeip.git
 cd connectedhomeip
-git checkout <telink_matter_branch>     # e.g. dev-tlk_v1.5
+git checkout <telink_matter_branch>     # e.g. release-v1.0-v1.5-branch
 ./scripts/checkout_submodules.py --platform telink,linux
 ```
 
@@ -184,16 +188,18 @@ Replace `<build_target>` with your board, e.g. `tlsr9518adk80d`, `tlsr9528a`,
 west build -b tl3238x
 ```
 
+<!--
 If your board has a flash size other than the default 2 MB, specify it:
 
 ```bash
 west build -b tl3238x -- -DFLASH_SIZE=4m
-```
+``` -->
 
-The built firmware is at `build/zephyr/zephyr.bin`. When MCUBoot + OTA is
-enabled, a merged `build/zephyr/merged.bin` (MCUBoot + app) is also generated.
+The built firmware is at `build/zephyr/zephyr.bin`.
 
-### 3.3 Build with build_examples.py (CI-style)
+<!-- When MCUBoot + OTA is enabled, a merged `build/zephyr/merged.bin` (MCUBoot + app) is also generated. -->
+
+<!-- ### 3.3 Build with build_examples.py (CI-style)
 
 Alternatively, use the Matter build system to build via GN:
 
@@ -210,7 +216,9 @@ List all available Telink targets:
 Common target options include `-compress-lzma`, `-ota`, `-dfu-smp`,
 `-factory-data`, `-shell`, `-rpcs`, and `-4mb-flash`.
 
-### 3.4 TL3238X build configurations
+### 3.4 TL3238X build configurations -->
+
+### 3.3 TL3238X build configurations
 
 TL3238X supports several configurations depending on flash size and dual-mode
 (Matter + Zigbee) needs. Key combinations:
@@ -232,19 +240,28 @@ west build -p -b tl3238x -d build_tl3238x_lzma_v1 -- \
   -DCONFIG_CHIP_DEVICE_SOFTWARE_VERSION=2
 ```
 
+If your board has a flash size other than the default 2 MB, specify it:
+
+```bash
+west build -b tl3238x -- -DFLASH_SIZE=4m
+```
+
 ## Step 4: Flash the firmware
 
+<!--
 ### 4.1 Option A: west flash (recommended for development)
 
 If your board is connected via a supported debug probe:
 
 ```bash
 west flash --erase
-```
+``` -->
 
-### 4.2 Option B: BDT (Telink flashing tool)
+<!-- ### 4.2 Option B: BDT (Telink flashing tool) -->
 
-Telink provides the **BDT** (Burning Debug Tool) for flashing. On Windows use
+### 4.1 BDT (Telink flashing tool)
+
+<!-- Telink provides the **BDT** (Burning Debug Tool) for flashing. On Windows use
 the BDT GUI (`Telink BDT.exe`); on Linux use the `bdt` CLI. See the
 [Telink Zephyr Getting Started — Flash the Firmware](https://github.com/telink-semi/zephyr/blob/develop/doc/telink/getting_started/index.md#flash-the-firmware)
 section for the chip-to-BDT name mapping and the unlock/erase/write flow.
@@ -258,10 +275,16 @@ A typical Linux BDT session:
 ```
 
 > For B92 / TL321X / TL721X, run `./bdt <chip> ulf` to unlock the flash before
-> erasing. For TL322X / TL323X, use the **TGui-BDT** tool (or `sctool` on Linux)
-> with the on-board programmer.
+> erasing. For TL323X, use the **TGui-BDT** tool (or `sctool` on Linux)
+> with the on-board programmer. -->
 
-### 4.3 UART console
+Telink provides the **BDT** (Burning Debug Tool) for flashing. On Windows use
+the BDT GUI (`Telink BDT.exe`). See the
+[Telink Zephyr Getting Started — Flash the Firmware](https://github.com/telink-semi/zephyr/blob/release-v1.0-v4.1-branch/doc/telink/getting_started/index.md#Flash-the-Firmware)
+
+<!-- ### 4.3 UART console -->
+
+### 4.2 UART console
 
 Connect UART to view device logs:
 
@@ -351,7 +374,7 @@ To test OTA with a Linux OTA Provider, refer to the
 
 -   [Telink Release Notes](./releases/telink_release_notes.md) — version info,
     chip/EVK versions, per-example support matrix, and resource usage tables.
--   [Telink Zephyr Getting Started](https://github.com/telink-semi/zephyr/blob/develop/doc/telink/getting_started/index.md)
+-   [Telink Zephyr Getting Started](https://github.com/telink-semi/zephyr/blob/release-v1.0-v4.1-branch/doc/telink/getting_started/index.md)
     — Zephyr SDK setup, BDT flashing details, and board overviews.
 -   Per-example `README.md` files under `examples/<app>/telink/` —
     example-specific build commands, button/LED mappings, and chip-tool usage.


### PR DESCRIPTION
#### Summary

Sync the release documentation changes from `release-v1.0-v1.5-branch` and
`pre_release-v1.2-v1.5-branch` into `dev-tlk_v1.5`.

- `pre_release-v1.2-v1.5-branch` is a linear descendant of `dev-tlk_v1.5`, so
  its tip `3ba0d7ed132` is brought in as-is (same commit hash) via fast-forward.
- `release-v1.0-v1.5-branch` diverged at the baseline, so its doc-only commit
  `1420141e55c` is cherry-picked onto the sync branch. Conflicts in
  `README.md` and `telink_release_notes.md` (also rewritten by the v1.2 doc
  commit) were resolved in favor of the newer v1.2 content; the v1.0-specific
  docs are still imported.

The resulting changes:

- Add `telink_release_notes_tl_v1.2.0-alpha-v1.5.1.0.md` and the current
  `telink_release_notes.md`.
- Add the release notes generator `generate_and_update_matter_notes.py` and
  update `README_BUILD_SCRIPT.md`.
- Add `telink_release_notes_tl_v1.0.1-rc1-v1.5.1.0.md` and update
  `telink_getting_started.md` from the v1.0 branch.
- Correct the TL323X chip version from `A0` to `A0/A1` across all release
  notes (development used A0, ecosystem/stress/stability testing used A1).

No code changes; docs only.

#### Related issues

N/A

#### Testing

- Docs only; no build or test impact.
- Verified the branch is linear on top of `dev-tlk_v1.5` (no merge commits).
- Verified TL323X chip version is updated consistently across all release note
  files.

#### Readability checklist

- [x] PR title is
      https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting
- [x] Apply the
      https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html
      rule (coding style)
- [x] PR size is short
- [x] Try to avoid "squashing" and "force-update" in commit history
- [x] CI time didn't increase

See: https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html