### PR TITLE
ci: add Mergify backport rules for telink release branches

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,42 +1,232 @@
 pull_request_rules:
-  - name: Label conflicting pull requests
-    description: Add a label to a pull request with conflict to spot it easily
-    conditions:
-      - conflict
-      - '-closed'
-    actions:
-      label:
-        toggle:
+    - name: Label conflicting pull requests
+      description: Add a label to a pull request with conflict to spot it easily
+      conditions:
           - conflict
-  # WARNING: If the rule name below is changed, you must also update the
-  # condition `check-failure~=Automatic merge on PullApprove` to match the new name.
-  - name: Automatic merge on PullApprove
-    conditions:
-      - or:
-          - check-success=pullapprove
-          - label="fast track"
-      - '#approved-reviews-by>=1'
-      - '#review-threads-unresolved=0'
-      - '-draft'
-      - label!=docker
-      # Workaround for Mergify deadlock due to using "#check-failure=0":
-      # Mergify’s own action check can appear as failed/cancelled if conditions stop matching;
-      # and GitHub keeps those historic failures forever. Since `#check-failure=0` counts ALL
-      # failures (including historic ones), this would cause a deadlock and block merges indefinitely.
-      # We whitelist only this self-check so merges aren’t deadlocked, while all other failures still block.
-      - or:
-          - '#check-failure=0'
-          - and:
-              - '#check-failure=1'
-              # WARNING: This must match the rule name defined above.
-              # If the rule name changes, update this condition accordingly.
-              - check-failure~=Automatic merge on PullApprove
-      - '#check-pending=0'
-      - check-success~=Build
-      - or:
-          - check-success=pullapprove
-          - check-skipped=pullapprove
-          - check-neutral=pullapprove
-    actions:
-      merge:
-        method: squash
+          - "-closed"
+      actions:
+          label:
+              toggle:
+                  - conflict
+    # WARNING: If the rule name below is changed, you must also update the
+    # condition `check-failure~=Automatic merge on PullApprove` to match the new name.
+    - name: Automatic merge on PullApprove
+      conditions:
+          - or:
+                - check-success=pullapprove
+                - label="fast track"
+          - "#approved-reviews-by>=1"
+          - "#review-threads-unresolved=0"
+          - "-draft"
+          - label!=docker
+          # Workaround for Mergify deadlock due to using "#check-failure=0":
+          # Mergify's own action check can appear as failed/cancelled if conditions stop matching;
+          # and GitHub keeps those historic failures forever. Since `#check-failure=0` counts ALL
+          # failures (including historic ones), this would cause a deadlock and block merges indefinitely.
+          # We whitelist only this self-check so merges aren't deadlocked, while all other failures still block.
+          - or:
+                - "#check-failure=0"
+                - and:
+                      - "#check-failure=1"
+                      # WARNING: This must match the rule name defined above.
+                      # If the rule name changes, update this condition accordingly.
+                      - check-failure~=Automatic merge on PullApprove
+          - "#check-pending=0"
+          - check-success~=Build
+          - or:
+                - check-success=pullapprove
+                - check-skipped=pullapprove
+                - check-neutral=pullapprove
+      actions:
+          merge:
+              method: squash
+
+    # Backport rules - cherry-pick the squashed master commit after merge.
+    # Apply a request-backport-* label (such as request-backport-latest or
+    # request-backport-supported) on the master PR (before or after merge)
+    # to trigger the corresponding backport.
+    - name: Backport to v1.7-branch
+      conditions:
+          - merged
+          - base=master
+          - or:
+                - label="request-backport-latest-mve-sve"
+                - label="request-backport-latest"
+                - label="request-backport-supported"
+      actions:
+          backport:
+              branches:
+                  - v1.7-branch
+              labels:
+                  - backport-v1.7-branch
+
+    - name: Backport to v1.6.1-branch
+      conditions:
+          - merged
+          - base=master
+          - or:
+                - label="request-backport-latest-mve-sve"
+                - label="request-backport-supported"
+      actions:
+          backport:
+              branches:
+                  - v1.6.1-branch
+              labels:
+                  - backport-v1.6.1-branch
+
+    - name: Backport to v1.6.1-mve-branch
+      conditions:
+          - merged
+          - base=master
+          - label="request-backport-latest-mve-sve"
+      actions:
+          backport:
+              branches:
+                  - v1.6.1-mve-branch
+              labels:
+                  - backport-v1.6.1-mve-branch
+
+    - name: Backport to v1.6-branch
+      conditions:
+          - merged
+          - base=master
+          - label="request-backport-supported"
+      actions:
+          backport:
+              branches:
+                  - v1.6-branch
+              labels:
+                  - backport-v1.6-branch
+
+    - name: Backport to v1.4.2-branch
+      conditions:
+          - merged
+          - base=master
+          - label="request-backport-supported"
+      actions:
+          backport:
+              branches:
+                  - v1.4.2-branch
+              labels:
+                  - backport-v1.4.2-branch
+
+    # Telink fork backport rules - cherry-pick the squashed dev/master commit.
+    # Apply a request-backport-<branch> label on a dev-tlk_v* / master PR.
+    - name: Backport to release-v1.0-v1.5-branch
+      conditions:
+          - merged
+          - or:
+                - base=master
+                - base~=^dev-tlk_
+          - label="request-backport-release-v1.0-v1.5-branch"
+      actions:
+          backport:
+              branches:
+                  - release-v1.0-v1.5-branch
+              labels:
+                  - backport-release-v1.0-v1.5-branch
+
+    - name: Backport to pre_release-v1.1-v1.5-branch
+      conditions:
+          - merged
+          - or:
+                - base=master
+                - base~=^dev-tlk_
+          - label="request-backport-pre_release-v1.1-v1.5-branch"
+      actions:
+          backport:
+              branches:
+                  - pre_release-v1.1-v1.5-branch
+              labels:
+                  - backport-pre_release-v1.1-v1.5-branch
+
+    - name: Backport to pre_release-v1.2-v1.5-branch
+      conditions:
+          - merged
+          - or:
+                - base=master
+                - base~=^dev-tlk_
+          - label="request-backport-pre_release-v1.2-v1.5-branch"
+      actions:
+          backport:
+              branches:
+                  - pre_release-v1.2-v1.5-branch
+              labels:
+                  - backport-pre_release-v1.2-v1.5-branch
+
+    - name: Backport to pre_release-v1.1-v1.6.1-branch
+      conditions:
+          - merged
+          - or:
+                - base=master
+                - base~=^dev-tlk_
+          - label="request-backport-pre_release-v1.1-v1.6.1-branch"
+      actions:
+          backport:
+              branches:
+                  - pre_release-v1.1-v1.6.1-branch
+              labels:
+                  - backport-pre_release-v1.1-v1.6.1-branch
+
+    - name: Backport to v1.5-branch
+      conditions:
+          - merged
+          - or:
+                - base=master
+                - base~=^dev-tlk_
+          - label="request-backport-v1.5-branch"
+      actions:
+          backport:
+              branches:
+                  - v1.5-branch
+              labels:
+                  - backport-v1.5-branch
+
+    - name: Request review for MVE/SVE backports
+      conditions:
+          - author=mergify[bot]
+          - or:
+                - label~=mve-branch
+                - label~=sve-branch
+      actions:
+          request_reviews:
+              users:
+                  - cecille
+
+    # Auto-merge backport PRs when CI is green and there are no conflicts.
+    # If a cherry-pick has conflicts or CI fails, the PR is left open for manual resolution.
+    # WARNING: If the rule name below is changed, you must also update the
+    # condition `check-failure~=Auto-merge clean backport PRs` to match the new name.
+    - name: Auto-merge clean backport PRs
+      conditions:
+          - or:
+                - label="backport-v1.7-branch"
+                - label="backport-v1.6.1-branch"
+                - label="backport-v1.6-branch"
+                - label="backport-v1.5-branch"
+                - label="backport-v1.4.2-branch"
+                - label="backport-release-v1.0-v1.5-branch"
+                - label="backport-pre_release-v1.1-v1.5-branch"
+                - label="backport-pre_release-v1.2-v1.5-branch"
+                - label="backport-pre_release-v1.1-v1.6.1-branch"
+          - author=mergify[bot]
+          - "-conflict"
+          - "-draft"
+          # Same deadlock workaround as above: allow exactly 1 failure if it is
+          # this rule's own self-check (which Mergify marks failed when conditions
+          # stop matching, and GitHub retains that historic failure forever).
+          - or:
+                - "#check-failure=0"
+                - and:
+                      - "#check-failure=1"
+                      # WARNING: This must match the rule name defined above.
+                      # If the rule name changes, update this condition accordingly.
+                      - check-failure~=Auto-merge clean backport PRs
+          - "#check-pending=0"
+          - check-success~=Build
+      actions:
+          merge:
+              method: squash
+
+merge_protections_settings:
+    reporting_method: check-runs


### PR DESCRIPTION
This is to enable Mergify for the Telink fork connectedhomeip.

### Summary

Extends the upstream `.mergify.yml` (all upstream rules kept intact) with
Mergify backport rules for the telink fork's release branches, reusing the
upstream project-chip backport mechanism:

- Trigger: `request-backport-<branch>` label added to a merged PR
- Result: Mergify opens a backport PR on `mergify/bp/<branch>/pr-<n>`, labeled
  `backport-<branch>`
- Auto-merge: backport PRs merge automatically when CI is green and conflict-free

### Backport targets

| Trigger label | Backports to |
|---|---|
| `request-backport-release-v1.0-v1.5-branch` | `release-v1.0-v1.5-branch` |
| `request-backport-pre_release-v1.1-v1.5-branch` | `pre_release-v1.1-v1.5-branch` |
| `request-backport-pre_release-v1.2-v1.5-branch` | `pre_release-v1.2-v1.5-branch` |
| `request-backport-pre_release-v1.1-v1.6.1-branch` | `pre_release-v1.1-v1.6.1-branch` |
| `request-backport-v1.5-branch` | `v1.5-branch` |

Source branches: `master` + `dev-tlk_v*` (both can trigger backports).

### What is kept from upstream

- All upstream backport rules (v1.7 / v1.6.1 / v1.6.1-mve / v1.6 / v1.4.2)
- `Automatic merge on PullApprove`
- `Request review for MVE/SVE backports`
- `Auto-merge clean backport PRs` (label list extended with the 4 new fork
  `backport-*` labels; `backport-v1.5-branch` already exists)
- `merge_protections_settings`

### Testing

- Sandbox verification in damien0x0023/connectedhomeip (default branch
  `dev-tlk_v1.5`):
  - merged PR #1 (Aliro door lock cherry-pick, base `dev-tlk_v1.5`);
  - added `request-backport-release-v1.0-v1.5-branch` to the merged PR;
  - Mergify automatically created backport PR #2 targeting
    `release-v1.0-v1.5-branch` (branch `mergify/bp/release-v1.0-v1.5-branch/pr-1`,
    label `backport-release-v1.0-v1.5-branch`).
- This PR itself is config-only (`.mergify.yml`); no runtime behavior change.
- Will re-verify on telink-semi with a test backport after merge.

### Follow-up

1. Install/enable the Mergify GitHub App on telink-semi (approved).
2. Create the `request-backport-*` / `backport-*` labels.
3. Switch the default branch to `dev-tlk_v1.5` (Mergify reads `.mergify.yml`
   from the default branch).
4. Verify with a test backport.

---

This is an auto-generated comment: release notes by coderabbit.ai 

## Summary by CodeRabbit

* **Chores**
  * Added automated backport workflows for stable, release, and Telink branches.
  * Added review requests for backport pull requests.
  * Enabled automatic squash-merging of eligible backports after successful CI checks.
  * Preserved existing conflict-labeling and automatic merge rules.

end of auto-generated comment: release notes by coderabbit.ai