### PR TITLE
telink: add tl7218x modual board overlay

### DIFF
--- a/.github/workflows/examples-telink.yaml
+++ b/.github/workflows/examples-telink.yaml
@@ -59,7 +59,7 @@ jobs:
 
             - name: Update Zephyr version 4.1.0 (develop) to specific revision (for developers purpose)
               run: 
-                scripts/run_in_build_env.sh "python3 scripts/tools/telink/update_zephyr.py https://github.com/telink-semi/tl_zephyr.git d6a8aa968e5fb97c0b63e2b436aced9084614c65 --sdk-repo https://github.com/telink-semi/tl_ble_sdk_zephyr.git --sdk-hash 3bddf885c0a1e4342393b7c6b668ece104c12102"
+                scripts/run_in_build_env.sh "python3 scripts/tools/telink/update_zephyr.py https://github.com/telink-semi/tl_zephyr.git 0858e43f05a91d84ab2fed77f3849ff589510b24 --sdk-repo https://github.com/telink-semi/tl_ble_sdk_zephyr.git --sdk-hash 3bddf885c0a1e4342393b7c6b668ece104c12102"
 
             - name: Build tools required for Factory Data
               # Run test for master and all PRs

--- a/src/platform/telink/tl7218x_ml7g_2m_flash.overlay
+++ b/src/platform/telink/tl7218x_ml7g_2m_flash.overlay
@@ -1,0 +1,59 @@
+&flash {
+	reg = <0x20000000 0x200000>;
+
+	/delete-node/ partitions;
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+// reserve 20k for software bootloader , 64k for mcuboot,need to disable log for mcuboot；		
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 0x15000>; 
+		};
+		slot0_partition: partition@15000 {
+			label = "image-0";
+			reg = <0x15000 0xe5000>; // total slot0 is 916k
+		};
+		slot1_partition: partition@fa000 {
+			label = "image-1";
+			reg = <0xfa000 0xe6000>; // total slot1 is 916k
+		};
+		user_rfu_partition: partition@1e0000 {
+ 			label = "user_rfu";
+			reg = <0x1e0000 0x4000>;
+ 		};
+        storage_partition: partition@1e4000 {
+			label = "matter-nvs";
+			reg = <0x1e4000 0x8000>; // matter nvs part , total is 32k.
+		};
+        user_partition: partition@1ec000 {
+			label = "user";
+			reg = <0x1ec000 0xc000>; // user part , total is 48k.
+		};
+		secure_partition: partition@1f8000 {
+ 			label = "secure";
+			reg = <0x1f8000 0x1000>; // secure info ,reserved for secure boot .if not use , can beused by other way .
+ 		};
+		user_config_partition: partition@1f9000 {
+ 			label = "user_config";
+			reg = <0x1f9000 0x1000>; // user_config ,for the secure-boot sign logic changes ,it can release for user .
+ 		};
+		dual_mode_partition: partition@1fa000 {
+ 			label = "dual-mode";
+			reg = <0x1fa000 0x2000>; // user:store the mode info and the key info part.same as public area for dual mode
+ 		};
+		dac_keypair_partition: partition@1fc000 {
+			label = "dac-keypair";
+			reg = <0x1fc000 0x1000>; // store dac and key pair.
+		};
+		factory_partition: partition@1fd000 {
+			label = "factory-data";
+			reg = <0x1fd000 0x1000>; // factory data info 
+		};
+		vendor_partition: partition@1fe000 {
+			label = "vendor-data";
+			reg = <0x1fe000 0x2000>; // mac and rf info.
+		};
+	};
+};

--- a/src/platform/telink/tl7218x_ml7g_2m_flash_lzma.overlay
+++ b/src/platform/telink/tl7218x_ml7g_2m_flash_lzma.overlay
@@ -1,0 +1,70 @@
+&flash {
+	reg = <0x20000000 0x200000>;
+
+	/delete-node/ partitions;
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 0x15000>;
+		};
+		slot0_partition: partition@15000 {
+			label = "image-0";
+			reg = <0x15000 0x120000>;
+		};
+		slot0_matter_partition: partition@15000_1 {
+			label = "image-0-matter";
+			reg = <0x15000 0xe5000>;
+		};
+		slot0_zb_partition: partition@fa000 {
+			label = "image-0-zb";
+			reg = <0xfa000 0x36000>;
+		};
+		slot0_trailor_partition: partition@130000 {
+			label = "image-0-trailor";
+			reg = <0x130000 0x5000>;
+		};
+		slot1_partition: partition@135000 {
+			label = "image-1";
+			reg = <0x135000 0xab000>;
+		};
+		user_rfu_partition: partition@1e0000 {
+			label = "user_rfu";
+			reg = <0x1e0000 0x4000>;
+		};
+		storage_partition: partition@1e4000 {
+			label = "matter-nvs";
+			reg = <0x1e4000 0x8000>;
+		};
+		zigbee_nvs_partition: partition@1ec000 {
+			label = "zigbee-nvs";
+			reg = <0x1ec000 0xc000>;
+		};
+		secure_partition: partition@1f8000 {
+			label = "secure";
+			reg = <0x1f8000 0x1000>;
+		};
+		user_config_partition: partition@1f9000 {
+			label = "user_config";
+			reg = <0x1f9000 0x1000>;
+		};
+		dual_mode_partition: partition@1fa000 {
+			label = "dual-mode";
+			reg = <0x1fa000 0x2000>;
+		};
+		dac_keypair_partition: partition@1fc000 {
+			label = "dac-keypair";
+			reg = <0x1fc000 0x1000>;
+		};
+		factory_partition: partition@1fd000 {
+			label = "factory-data";
+			reg = <0x1fd000 0x1000>;
+		};
+		vendor_partition: partition@1fe000 {
+			label = "vendor-data";
+			reg = <0x1fe000 0x2000>;
+		};
+	};
+};

--- a/src/platform/telink/tl7218x_ml7m_2m_flash.overlay
+++ b/src/platform/telink/tl7218x_ml7m_2m_flash.overlay
@@ -1,0 +1,59 @@
+&flash {
+	reg = <0x20000000 0x200000>;
+
+	/delete-node/ partitions;
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+// reserve 20k for software bootloader , 64k for mcuboot,need to disable log for mcuboot；		
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 0x15000>; 
+		};
+		slot0_partition: partition@15000 {
+			label = "image-0";
+			reg = <0x15000 0xe5000>; // total slot0 is 916k
+		};
+		slot1_partition: partition@fa000 {
+			label = "image-1";
+			reg = <0xfa000 0xe6000>; // total slot1 is 916k
+		};
+		user_rfu_partition: partition@1e0000 {
+ 			label = "user_rfu";
+			reg = <0x1e0000 0x4000>;
+ 		};
+        storage_partition: partition@1e4000 {
+			label = "matter-nvs";
+			reg = <0x1e4000 0x8000>; // matter nvs part , total is 32k.
+		};
+        user_partition: partition@1ec000 {
+			label = "user";
+			reg = <0x1ec000 0xc000>; // user part , total is 48k.
+		};
+		secure_partition: partition@1f8000 {
+ 			label = "secure";
+			reg = <0x1f8000 0x1000>; // secure info ,reserved for secure boot .if not use , can beused by other way .
+ 		};
+		user_config_partition: partition@1f9000 {
+ 			label = "user_config";
+			reg = <0x1f9000 0x1000>; // user_config ,for the secure-boot sign logic changes ,it can release for user .
+ 		};
+		dual_mode_partition: partition@1fa000 {
+ 			label = "dual-mode";
+			reg = <0x1fa000 0x2000>; // user:store the mode info and the key info part.same as public area for dual mode
+ 		};
+		dac_keypair_partition: partition@1fc000 {
+			label = "dac-keypair";
+			reg = <0x1fc000 0x1000>; // store dac and key pair.
+		};
+		factory_partition: partition@1fd000 {
+			label = "factory-data";
+			reg = <0x1fd000 0x1000>; // factory data info 
+		};
+		vendor_partition: partition@1fe000 {
+			label = "vendor-data";
+			reg = <0x1fe000 0x2000>; // mac and rf info.
+		};
+	};
+};

--- a/src/platform/telink/tl7218x_ml7m_2m_flash_lzma.overlay
+++ b/src/platform/telink/tl7218x_ml7m_2m_flash_lzma.overlay
@@ -1,0 +1,70 @@
+&flash {
+	reg = <0x20000000 0x200000>;
+
+	/delete-node/ partitions;
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 0x15000>;
+		};
+		slot0_partition: partition@15000 {
+			label = "image-0";
+			reg = <0x15000 0x120000>;
+		};
+		slot0_matter_partition: partition@15000_1 {
+			label = "image-0-matter";
+			reg = <0x15000 0xe5000>;
+		};
+		slot0_zb_partition: partition@fa000 {
+			label = "image-0-zb";
+			reg = <0xfa000 0x36000>;
+		};
+		slot0_trailor_partition: partition@130000 {
+			label = "image-0-trailor";
+			reg = <0x130000 0x5000>;
+		};
+		slot1_partition: partition@135000 {
+			label = "image-1";
+			reg = <0x135000 0xab000>;
+		};
+		user_rfu_partition: partition@1e0000 {
+			label = "user_rfu";
+			reg = <0x1e0000 0x4000>;
+		};
+		storage_partition: partition@1e4000 {
+			label = "matter-nvs";
+			reg = <0x1e4000 0x8000>;
+		};
+		zigbee_nvs_partition: partition@1ec000 {
+			label = "zigbee-nvs";
+			reg = <0x1ec000 0xc000>;
+		};
+		secure_partition: partition@1f8000 {
+			label = "secure";
+			reg = <0x1f8000 0x1000>;
+		};
+		user_config_partition: partition@1f9000 {
+			label = "user_config";
+			reg = <0x1f9000 0x1000>;
+		};
+		dual_mode_partition: partition@1fa000 {
+			label = "dual-mode";
+			reg = <0x1fa000 0x2000>;
+		};
+		dac_keypair_partition: partition@1fc000 {
+			label = "dac-keypair";
+			reg = <0x1fc000 0x1000>;
+		};
+		factory_partition: partition@1fd000 {
+			label = "factory-data";
+			reg = <0x1fd000 0x1000>;
+		};
+		vendor_partition: partition@1fe000 {
+			label = "vendor-data";
+			reg = <0x1fe000 0x2000>;
+		};
+	};
+};


### PR DESCRIPTION
#### Summary

This PR adds 2MB flash partition overlay support for the Telink TL7218X ML7G and ML7M module boards, and updates the Zephyr revision to pull up the SWS pin after startup and retention reset.

**What was changed:**

- Add 4 new flash overlay files under `src/platform/telink/`:
  - `tl7218x_ml7g_2m_flash.overlay` / `tl7218x_ml7m_2m_flash.overlay` — dual image-0/image-1 slots with storage (matter-nvs), user, secure, dual-mode, dac-keypair, factory-data and vendor-data partitions.
  - `tl7218x_ml7g_2m_flash_lzma.overlay` / `tl7218x_ml7m_2m_flash_lzma.overlay` — LZMA-compressed image layout with dedicated image-0-matter, image-0-zb, image-0-trailor sub-partitions and zigbee-nvs.
- Update the Zephyr revision pinned in `.github/workflows/examples-telink.yaml` (`d6a8aa9…` → `0858e43…`) to pick up the fix that pulls up the SWS pin after startup and retention reset, preventing the debug tool connection issue.

**Why:**

The TL7218X ML7G/ML7M module boards ship with 2MB flash, which needs dedicated partition overlays to properly layout the Matter image, storage, and Zigbee NVS partitions in both standard and LZMA-compressed modes. The Zephyr revision bump is required for the SWS pin pull-up fix on these boards.

#### Related issues

N/A

#### Testing

Currently compiling and testing.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the code readable:

- [ ] PR title is `https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting`
- [ ] Apply the `https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html` rule (coding style)
- [ ] PR size is short
- [ ] Try to avoid "squashing" and "force-update" in commit history
- [ ] CI time didn't increase

See: `https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Added dedicated 2 MB flash layouts for TL7218X ML7G and ML7M devices.
  - Defined storage regions for bootloader, firmware images, Matter/Zigbee data, configuration, security keys, factory data, and vendor data.
  - Updated the Telink SDK workflow to use a newer pinned repository revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->