### PR TITLE
telink: update tl_zephyr revision for zigbee-to-matter switch

### DIFF
--- a/.github/workflows/examples-telink.yaml
+++ b/.github/workflows/examples-telink.yaml
@@ -59,7 +59,7 @@ jobs:
 
             - name: Update Zephyr version 4.1.0 (develop) to specific revision (for developers purpose)
               run: 
-                scripts/run_in_build_env.sh "python3 scripts/tools/telink/update_zephyr.py https://github.com/telink-semi/tl_zephyr.git d6a8aa968e5fb97c0b63e2b436aced9084614c65 --sdk-repo https://github.com/telink-semi/tl_ble_sdk_zephyr.git --sdk-hash 3bddf885c0a1e4342393b7c6b668ece104c12102"
+                scripts/run_in_build_env.sh "python3 scripts/tools/telink/update_zephyr.py https://github.com/telink-semi/tl_zephyr.git e87fbee38775b103bd676f8412e6a9d651f08d6b --sdk-repo https://github.com/telink-semi/tl_ble_sdk_zephyr.git --sdk-hash 3bddf885c0a1e4342393b7c6b668ece104c12102"
 
             - name: Build tools required for Factory Data
               # Run test for master and all PRs


### PR DESCRIPTION
Update the tl_zephyr revision used by the Telink examples workflow from
d6a8aa968e5fb97c0b63e2b436aced9084614c65 to
e87fbee38775b103bd676f8412e6a9d651f08d6b (HEAD of the dev-tlk_v4.1
branch).

The new revision adds:
- soc: telink_tl521x: reset radio at boot for zigbee-to-matter switch
  (telink-semi/tl_zephyr#836): add an RF reset sequence in
  soc_early_init_hook (only when PM and MCUboot are disabled) to support
  switching from Zigbee to Matter for lighting devices on TL521X,
  mirroring the existing telink_tl323x logic.

#### Summary

Update the tl_zephyr revision pinned in the Telink examples workflow so
the TL521X lighting-app build picks up the new RF reset sequence
("soc: telink_tl521x: reset radio at boot for zigbee-to-matter switch",
telink-semi/tl_zephyr#836). This change is required for a Zigbee device to switch
to Matter correctly at boot on TL521X (the RF reset runs only when PM
and MCUboot are disabled, matching the telink_tl323x behavior).

The BLE SDK hash is unchanged.

#### Related issues

N/A

#### Testing

- Verified on TL521X lighting-app (4MB flash dual-mode configuration).
- Zigbee-to-Matter dual-mode switching works normally, and after
  switching to Matter the device can join the Amazon (Alexa) ecosystem
  and be commissioned normally.

#### Readability checklist

-   [x] PR title is
        `https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting`
-   [x] Apply the
        `https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html`
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: `https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Telink build workflow to use a newer Zephyr revision.
  - The Bluetooth SDK revision remains unchanged.
  - No user-facing feature or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->