### PR TITLE
ci: telink: add backport rule and fix v1.4.0 release notes

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -182,6 +182,20 @@ pull_request_rules:
               labels:
                   - backport-v1.5-branch
 
+    - name: Backport to release-v1.4-v1.5-branch
+      conditions:
+          - merged
+          - or:
+                - base=master
+                - base~=^dev-tlk_
+          - label="request-backport-release-v1.4-v1.5-branch"
+      actions:
+          backport:
+              branches:
+                  - release-v1.4-v1.5-branch
+              labels:
+                  - backport-release-v1.4-v1.5-branch
+
     - name: Request review for MVE/SVE backports
       conditions:
           - author=mergify[bot]
@@ -206,6 +220,7 @@ pull_request_rules:
                 - label="backport-v1.5-branch"
                 - label="backport-v1.4.2-branch"
                 - label="backport-release-v1.0-v1.5-branch"
+                - label="backport-release-v1.4-v1.5-branch"
                 - label="backport-pre_release-v1.1-v1.5-branch"
                 - label="backport-pre_release-v1.2-v1.5-branch"
                 - label="backport-pre_release-v1.1-v1.6.1-branch"

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -8,5 +8,5 @@
     "bracketSpacing": true,
     "jsxBracketSameLine": false,
     "arrowParens": "avoid",
-    "proseWrap": "always"
+    "proseWrap": "preserve"
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -8,5 +8,13 @@
     "bracketSpacing": true,
     "jsxBracketSameLine": false,
     "arrowParens": "avoid",
-    "proseWrap": "preserve"
+    "proseWrap": "always",
+    "overrides": [
+        {
+            "files": ["*_cn.md", "**/*_cn.md"],
+            "options": {
+                "proseWrap": "preserve"
+            }
+        }
+    ]
 }

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Connected Home over IP (CHIP) project**
 Telink Matter SDK is a software development platform that implements the Matter
 protocol on Telink RISC-V SoC platforms. It is built on top of the Connected
 Home over IP (CHIP) project and integrates with the Telink Zephyr SDK to provide
-complete Matter-over-Thread support for Telink chips.
+complete Matter over Thread support for Telink chips.
 
 ### SDK Core Capabilities
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -2,7 +2,7 @@
 
 -   [英文 README](README.md)
 
-[![Telink Website](https://img.shields.io/badge/Website-Telink-blue?style=flat-square)](https://www.telink-semi.com/)
+[![Telink Website](https://img.shields.io/badge/Website-Telink-blue?style=flat-square)](https://www.telink-semi.cn/)
 [![Forum](https://img.shields.io/badge/Forum-Telink-green?style=flat-square)](https://forum.telink-semi.cn/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-red?style=flat-square)](LICENSE)
 [![Matter](https://img.shields.io/badge/Matter-v1.5-green?style=flat-square)](https://github.com/project-chip/connectedhomeip)
@@ -12,14 +12,14 @@
 > 📖 本文档是 **Telink Matter SDK**（fork）的 README。上游 Matter（Project
 > CHIP）的 README 请参阅 [MATTER_README.md](MATTER_README.md)。
 
-**基于 Connected Home over IP（CHIP）项目的 Telink RISC-V SoC 平台 Matter 协议实
-现**
+**基于 Connected Home over IP（CHIP）项目的 Telink RISC-V SoC 平台 Matter
+协议实现**
 
 -   开发环境搭建、SDK 获取及快速上手说明，请参阅
     [Telink Matter Getting Started Guide](docs/platforms/telink/telink_getting_started.md)。
 -   更深入的讲解，请参阅在线
     [Telink Matter Developer Guide](https://doc.telink-semi.cn/doc/zh/software/res/sdk/matter/telink_matter_developer_guide_cn/)
-    （**Obtaining Matter Source Code** 章节包含初始环境搭建）。
+    （**获取 Matter 源代码** 章节包含初始环境搭建）。
 -   支持的设备及资源占用的详细列表，请参阅
     [Release Note](docs/platforms/telink/releases/telink_release_notes.md)
 
@@ -27,9 +27,9 @@
 
 ## 📖 SDK 介绍
 
-Telink Matter SDK 是一个在 Telink RISC-V SoC 平台上实现 Matter 协议的软件开发平
-台。它基于 Connected Home over IP（CHIP）项目构建，并集成 Telink Zephyr SDK，为
-Telink 芯片提供完整的 Matter-over-Thread 支持。
+Telink Matter SDK 是一个在 Telink RISC-V SoC 平台上实现 Matter 协议的软件开发平台。
+它基于 Connected Home over IP（CHIP）项目构建，并集成 Telink Zephyr SDK，
+为 Telink 芯片提供完整的 Matter over Thread 支持。
 
 ### SDK 核心能力
 
@@ -45,8 +45,8 @@ Telink 芯片提供完整的 Matter-over-Thread 支持。
 | 启动管理    | MCUboot 引导加载程序集成                |
 | 示例应用    | 多个 Matter 示例应用，用于验证与开发    |
 
-您可以基于本 SDK 开发具有跨厂商互操作能力的 Telink Matter 智能家居终端设备，覆盖
-从原型验证、设备开发到量产测试的完整流程。
+您可以基于本 SDK 开发具有跨厂商互操作能力的 Telink Matter 智能家居终端设备，
+覆盖从原型验证、设备开发到量产测试的完整流程。
 
 ### 典型应用
 
@@ -60,8 +60,8 @@ Telink 芯片提供完整的 Matter-over-Thread 支持。
 
 ### 支持的示例
 
-本 SDK 为以下 Matter 示例应用提供 Telink 平台移植。每个 release 实际验证过的芯片
-/EVK 支持矩阵，请参阅
+本 SDK 为以下 Matter 示例应用提供 Telink 平台移植。每个 release 实际验证过的
+芯片/EVK 支持矩阵，请参阅
 [Release Note](docs/platforms/telink/releases/telink_release_notes.md)。
 
 | 类别               | 示例                                                                                                                                                                                                     |
@@ -71,8 +71,8 @@ Telink 芯片提供完整的 Matter-over-Thread 支持。
 
 ### 支持信息
 
-关于完整、准确的芯片型号、对应的开发板、开发平台、工具链以及 SDK 版本的详细信息
-，请参阅
+关于完整、准确的芯片型号、对应的开发板、开发平台、工具链以及 SDK 版本的详细信息，
+请参阅
 [Release Notes](docs/platforms/telink/releases/telink_release_notes.md)。打开
 Release Notes 页面后，通过左侧下拉列表，选择与您当前使用的 SDK 版本对应的
 Release Notes 查看。
@@ -95,7 +95,7 @@ Release Notes 查看。
 
 | 类型                   | 资源                                                                                                                         |
 | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| 🌐 **Telink 官方网站** | [Telink - Chips for a Smarter IoT](https://www.telink-semi.com/)                                                             |
+| 🌐 **Telink 官方网站** | [Telink - Chips for a Smarter IoT](https://www.telink-semi.cn/)                                                              |
 | 💬 **Telink 论坛**     | [Telink Technical Support](https://forum.telink-semi.cn/)                                                                    |
 | 📖 **文档**            | [Telink Matter Developer Guide](https://doc.telink-semi.cn/doc/zh/software/res/sdk/matter/telink_matter_developer_guide_cn/) |
 | 📦 **Matter 社区项目** | [Connected Home over IP](https://github.com/project-chip/connectedhomeip)                                                    |

--- a/docs/platforms/telink/releases/telink_release_notes.md
+++ b/docs/platforms/telink/releases/telink_release_notes.md
@@ -41,23 +41,27 @@ Matter-over-Thread device on TL521X (A0) with the lighting-app.
 -   ✅ LZMA compression support for OTA images
 -   ✅ Factory data provisioning support
 -   ✅ Matter + Zigbee dual-mode support on 4MB flash
--   ✅ Add Aliro (Apple Home) delegate for the door lock example (#25)
+-   ✅ Add Aliro (Apple Home) delegate for the door lock example
+    ([#25](https://github.com/telink-semi/tl_matter/pull/25))
 -   ✅ Enable `APP_SET_DEVICE_INFO_PROVIDER` for the All Clusters Minimal
-    example (#40)
+    example ([#40](https://github.com/telink-semi/tl_matter/pull/40))
 
-> **Note:** The Aliro door-lock delegate (#25) and All Clusters Minimal
-> `APP_SET_DEVICE_INFO_PROVIDER` (#40) are code contributions not covered by
-> this release's validated support matrix (lighting-app on TL521X only).
+> **Note:** The Aliro door-lock delegate
+> ([#25](https://github.com/telink-semi/tl_matter/pull/25)) and All Clusters
+> Minimal `APP_SET_DEVICE_INFO_PROVIDER`
+> ([#40](https://github.com/telink-semi/tl_matter/pull/40)) are code
+> contributions not covered by this release's validated support matrix
+> (lighting-app on TL521X only).
 
 ---
 
 ## 🐛 Bug Fixes
 
-| Issue | Component | Description                                                                                                                                                      |
-| ----- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| #40   | Build     | Compile `DFUOverSMP.cpp` in the common chip-module so examples using `AppTaskCommon.cpp` link DFU-over-SMP support (fixes `air-quality-sensor-app` link failure) |
-| #47   | Build/OTA | Use `SOC_FAMILY_TELINK_TLX` instead of the removed `SOC_RISCV_TELINK_TLX` so the MCUboot build target is not skipped on TLX-family OTA builds                    |
-| #51   | SoC       | Update the `tl_zephyr` revision to add the TL521X radio reset at boot for the Zigbee→Matter switch (Zephyr #836)                                                 |
+| Issue                                                   | Component | Description                                                                                                                                                           |
+| ------------------------------------------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [#40](https://github.com/telink-semi/tl_matter/pull/40) | Build     | Compile `DFUOverSMP.cpp` in the common chip-module so examples using `AppTaskCommon.cpp` link DFU-over-SMP support (fixes `air-quality-sensor-app` link failure)      |
+| [#47](https://github.com/telink-semi/tl_matter/pull/47) | Build/OTA | Use `SOC_FAMILY_TELINK_TLX` instead of the removed `SOC_RISCV_TELINK_TLX` so the MCUboot build target is not skipped on TLX-family OTA builds                         |
+| [#51](https://github.com/telink-semi/tl_matter/pull/51) | SoC       | Update the `tl_zephyr` revision to add the TL521X radio reset at boot for the Zigbee→Matter switch (Zephyr [#836](https://github.com/telink-semi/tl_zephyr/pull/836)) |
 
 ---
 

--- a/docs/platforms/telink/releases/telink_release_notes.md
+++ b/docs/platforms/telink/releases/telink_release_notes.md
@@ -1,6 +1,6 @@
 # Telink Matter SDK Release Note
 
-[![Version](https://img.shields.io/badge/Version-tl_v1.4.0-v1.5-blue?style=flat-square)](https://github.com/telink-semi/tl_matter/releases/tag/tl_v1.4.0-v1.5)
+[![Version](https://img.shields.io/badge/Version-tl__v1.4.0--v1.5-blue?style=flat-square)](https://github.com/telink-semi/tl_matter/releases/tag/tl_v1.4.0-v1.5)
 [![License](https://img.shields.io/badge/License-Apache%202.0-red?style=flat-square)](../../../../LICENSE)
 [![Matter](https://img.shields.io/badge/Matter-v1.5-green?style=flat-square)](https://github.com/project-chip/connectedhomeip/commit/f4a8cf98ada4ad4f439b45e360800693cc5f1391)
 
@@ -14,10 +14,9 @@
 
 ## 📖 Introduction
 
-This release is based on the `dev-tlk_v1.5` branch, providing Matter protocol
-support for the Telink TL521X SoC platform. It integrates the Matter SDK with
-the Telink Zephyr SDK to enable a Matter-over-Thread device on TL521X (A0) with
-the lighting-app.
+This release provides Matter protocol support for the Telink TL521X SoC
+platform. It integrates the Matter SDK with the Telink Zephyr SDK to enable a
+Matter-over-Thread device on TL521X (A0) with the lighting-app.
 
 ---
 
@@ -64,15 +63,15 @@ the lighting-app.
 
 ## 📦 Updates / Dependencies
 
-| Component                 | Repository                                                                          | Commit                                                                                                         | Notes                                                                   |
-| ------------------------- | ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
-| **Telink Zephyr SDK**     | [telink-semi/tl_zephyr](https://github.com/telink-semi/tl_zephyr)                   | [`ec302e9`](https://github.com/telink-semi/tl_zephyr/commit/ec302e94cb2886f0c71515efbe7344b32449a9ff)          | Tracks `dev-tlk_v4.1`; TL521x SoC split + radio reset for Zigbee→Matter |
-| **Telink BLE SDK**        | [telink-semi/tl_ble_sdk_zephyr](https://github.com/telink-semi/tl_ble_sdk_zephyr)   | [`de6f125`](https://github.com/telink-semi/tl_ble_sdk_zephyr/commit/de6f125c8ae6d29c4a640ab3526b40ff8c3f0a20)  | Required by TL521X                                                      |
-| **Telink HAL Zephyr**     | [telink-semi/hal_telink](https://github.com/telink-semi/hal_telink)                 | [`bd870dc`](https://github.com/telink-semi/hal_telink/commit/bd870dc273989756f908077761a5e3adbd7d108f)         | Contains hal_v1 and hal_v2 sources                                      |
-| **MCUBoot**               | [telink-semi/tl_mcuboot](https://github.com/telink-semi/tl_mcuboot)                 | [`ce0da85`](https://github.com/telink-semi/tl_mcuboot/commit/ce0da85c39c749df49b0ec62b33d2ecdea24c927)         | Bootloader; required for OTA/DFU                                        |
-| **OpenThread Telink**     | [telink-semi/tl_openthread](https://github.com/telink-semi/tl_openthread)           | [`542aaab`](https://github.com/telink-semi/tl_openthread/commit/542aaab44e1308e1a8a24573dfbd413fade342ee)      | OpenThread source adapted for Telink                                    |
-| **OpenThread Telink Lib** | [telink-semi/tl_openthread_libs](https://github.com/telink-semi/tl_openthread_libs) | [`f69c186`](https://github.com/telink-semi/tl_openthread_libs/commit/f69c186d65a41259480e87ccf9d2a7f665249778) | Pre-built OpenThread library for Telink                                 |
-| **Telink XZ (LZMA)**      | [telink-semi/tl_xz](https://github.com/telink-semi/tl_xz)                           | [`831f338`](https://github.com/telink-semi/tl_xz/commit/831f338fd6784661d3bec62fd01060ee4d7d373d)              | LZMA compression library module                                         |
+| Component                 | Repository                                                                          | Commit                                                                                                         | Notes                                            |
+| ------------------------- | ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| **Telink Zephyr SDK**     | [telink-semi/tl_zephyr](https://github.com/telink-semi/tl_zephyr)                   | [`ec302e9`](https://github.com/telink-semi/tl_zephyr/commit/ec302e94cb2886f0c71515efbe7344b32449a9ff)          | TL521x SoC split + radio reset for Zigbee→Matter |
+| **Telink BLE SDK**        | [telink-semi/tl_ble_sdk_zephyr](https://github.com/telink-semi/tl_ble_sdk_zephyr)   | [`de6f125`](https://github.com/telink-semi/tl_ble_sdk_zephyr/commit/de6f125c8ae6d29c4a640ab3526b40ff8c3f0a20)  | Required by TL521X                               |
+| **Telink HAL Zephyr**     | [telink-semi/hal_telink](https://github.com/telink-semi/hal_telink)                 | [`bd870dc`](https://github.com/telink-semi/hal_telink/commit/bd870dc273989756f908077761a5e3adbd7d108f)         | Contains hal_v1 and hal_v2 sources               |
+| **MCUBoot**               | [telink-semi/tl_mcuboot](https://github.com/telink-semi/tl_mcuboot)                 | [`ce0da85`](https://github.com/telink-semi/tl_mcuboot/commit/ce0da85c39c749df49b0ec62b33d2ecdea24c927)         | Bootloader; required for OTA/DFU                 |
+| **OpenThread Telink**     | [telink-semi/tl_openthread](https://github.com/telink-semi/tl_openthread)           | [`542aaab`](https://github.com/telink-semi/tl_openthread/commit/542aaab44e1308e1a8a24573dfbd413fade342ee)      | OpenThread source adapted for Telink             |
+| **OpenThread Telink Lib** | [telink-semi/tl_openthread_libs](https://github.com/telink-semi/tl_openthread_libs) | [`f69c186`](https://github.com/telink-semi/tl_openthread_libs/commit/f69c186d65a41259480e87ccf9d2a7f665249778) | Pre-built OpenThread library for Telink          |
+| **Telink XZ (LZMA)**      | [telink-semi/tl_xz](https://github.com/telink-semi/tl_xz)                           | [`831f338`](https://github.com/telink-semi/tl_xz/commit/831f338fd6784661d3bec62fd01060ee4d7d373d)              | LZMA compression library module                  |
 
 -   Updated Zephyr SDK references from `telink-semi/zephyr` to
     `telink-semi/tl_zephyr` (repo renamed, links updated accordingly).

--- a/docs/platforms/telink/releases/telink_release_notes_tl_v1.4.0-v1.5.1.0.md
+++ b/docs/platforms/telink/releases/telink_release_notes_tl_v1.4.0-v1.5.1.0.md
@@ -41,23 +41,27 @@ Matter-over-Thread device on TL521X (A0) with the lighting-app.
 -   ✅ LZMA compression support for OTA images
 -   ✅ Factory data provisioning support
 -   ✅ Matter + Zigbee dual-mode support on 4MB flash
--   ✅ Add Aliro (Apple Home) delegate for the door lock example (#25)
+-   ✅ Add Aliro (Apple Home) delegate for the door lock example
+    ([#25](https://github.com/telink-semi/tl_matter/pull/25))
 -   ✅ Enable `APP_SET_DEVICE_INFO_PROVIDER` for the All Clusters Minimal
-    example (#40)
+    example ([#40](https://github.com/telink-semi/tl_matter/pull/40))
 
-> **Note:** The Aliro door-lock delegate (#25) and All Clusters Minimal
-> `APP_SET_DEVICE_INFO_PROVIDER` (#40) are code contributions not covered by
-> this release's validated support matrix (lighting-app on TL521X only).
+> **Note:** The Aliro door-lock delegate
+> ([#25](https://github.com/telink-semi/tl_matter/pull/25)) and All Clusters
+> Minimal `APP_SET_DEVICE_INFO_PROVIDER`
+> ([#40](https://github.com/telink-semi/tl_matter/pull/40)) are code
+> contributions not covered by this release's validated support matrix
+> (lighting-app on TL521X only).
 
 ---
 
 ## 🐛 Bug Fixes
 
-| Issue | Component | Description                                                                                                                                                      |
-| ----- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| #40   | Build     | Compile `DFUOverSMP.cpp` in the common chip-module so examples using `AppTaskCommon.cpp` link DFU-over-SMP support (fixes `air-quality-sensor-app` link failure) |
-| #47   | Build/OTA | Use `SOC_FAMILY_TELINK_TLX` instead of the removed `SOC_RISCV_TELINK_TLX` so the MCUboot build target is not skipped on TLX-family OTA builds                    |
-| #51   | SoC       | Update the `tl_zephyr` revision to add the TL521X radio reset at boot for the Zigbee→Matter switch (Zephyr #836)                                                 |
+| Issue                                                   | Component | Description                                                                                                                                                           |
+| ------------------------------------------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [#40](https://github.com/telink-semi/tl_matter/pull/40) | Build     | Compile `DFUOverSMP.cpp` in the common chip-module so examples using `AppTaskCommon.cpp` link DFU-over-SMP support (fixes `air-quality-sensor-app` link failure)      |
+| [#47](https://github.com/telink-semi/tl_matter/pull/47) | Build/OTA | Use `SOC_FAMILY_TELINK_TLX` instead of the removed `SOC_RISCV_TELINK_TLX` so the MCUboot build target is not skipped on TLX-family OTA builds                         |
+| [#51](https://github.com/telink-semi/tl_matter/pull/51) | SoC       | Update the `tl_zephyr` revision to add the TL521X radio reset at boot for the Zigbee→Matter switch (Zephyr [#836](https://github.com/telink-semi/tl_zephyr/pull/836)) |
 
 ---
 

--- a/docs/platforms/telink/releases/telink_release_notes_tl_v1.4.0-v1.5.1.0.md
+++ b/docs/platforms/telink/releases/telink_release_notes_tl_v1.4.0-v1.5.1.0.md
@@ -1,6 +1,6 @@
 # Telink Matter SDK Release Note
 
-[![Version](https://img.shields.io/badge/Version-tl_v1.4.0-v1.5-blue?style=flat-square)](https://github.com/telink-semi/tl_matter/releases/tag/tl_v1.4.0-v1.5)
+[![Version](https://img.shields.io/badge/Version-tl__v1.4.0--v1.5-blue?style=flat-square)](https://github.com/telink-semi/tl_matter/releases/tag/tl_v1.4.0-v1.5)
 [![License](https://img.shields.io/badge/License-Apache%202.0-red?style=flat-square)](../../../../LICENSE)
 [![Matter](https://img.shields.io/badge/Matter-v1.5-green?style=flat-square)](https://github.com/project-chip/connectedhomeip/commit/f4a8cf98ada4ad4f439b45e360800693cc5f1391)
 
@@ -14,10 +14,9 @@
 
 ## 📖 Introduction
 
-This release is based on the `dev-tlk_v1.5` branch, providing Matter protocol
-support for the Telink TL521X SoC platform. It integrates the Matter SDK with
-the Telink Zephyr SDK to enable a Matter-over-Thread device on TL521X (A0) with
-the lighting-app.
+This release provides Matter protocol support for the Telink TL521X SoC
+platform. It integrates the Matter SDK with the Telink Zephyr SDK to enable a
+Matter-over-Thread device on TL521X (A0) with the lighting-app.
 
 ---
 
@@ -64,15 +63,15 @@ the lighting-app.
 
 ## 📦 Updates / Dependencies
 
-| Component                 | Repository                                                                          | Commit                                                                                                         | Notes                                                                   |
-| ------------------------- | ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
-| **Telink Zephyr SDK**     | [telink-semi/tl_zephyr](https://github.com/telink-semi/tl_zephyr)                   | [`ec302e9`](https://github.com/telink-semi/tl_zephyr/commit/ec302e94cb2886f0c71515efbe7344b32449a9ff)          | Tracks `dev-tlk_v4.1`; TL521x SoC split + radio reset for Zigbee→Matter |
-| **Telink BLE SDK**        | [telink-semi/tl_ble_sdk_zephyr](https://github.com/telink-semi/tl_ble_sdk_zephyr)   | [`de6f125`](https://github.com/telink-semi/tl_ble_sdk_zephyr/commit/de6f125c8ae6d29c4a640ab3526b40ff8c3f0a20)  | Required by TL521X                                                      |
-| **Telink HAL Zephyr**     | [telink-semi/hal_telink](https://github.com/telink-semi/hal_telink)                 | [`bd870dc`](https://github.com/telink-semi/hal_telink/commit/bd870dc273989756f908077761a5e3adbd7d108f)         | Contains hal_v1 and hal_v2 sources                                      |
-| **MCUBoot**               | [telink-semi/tl_mcuboot](https://github.com/telink-semi/tl_mcuboot)                 | [`ce0da85`](https://github.com/telink-semi/tl_mcuboot/commit/ce0da85c39c749df49b0ec62b33d2ecdea24c927)         | Bootloader; required for OTA/DFU                                        |
-| **OpenThread Telink**     | [telink-semi/tl_openthread](https://github.com/telink-semi/tl_openthread)           | [`542aaab`](https://github.com/telink-semi/tl_openthread/commit/542aaab44e1308e1a8a24573dfbd413fade342ee)      | OpenThread source adapted for Telink                                    |
-| **OpenThread Telink Lib** | [telink-semi/tl_openthread_libs](https://github.com/telink-semi/tl_openthread_libs) | [`f69c186`](https://github.com/telink-semi/tl_openthread_libs/commit/f69c186d65a41259480e87ccf9d2a7f665249778) | Pre-built OpenThread library for Telink                                 |
-| **Telink XZ (LZMA)**      | [telink-semi/tl_xz](https://github.com/telink-semi/tl_xz)                           | [`831f338`](https://github.com/telink-semi/tl_xz/commit/831f338fd6784661d3bec62fd01060ee4d7d373d)              | LZMA compression library module                                         |
+| Component                 | Repository                                                                          | Commit                                                                                                         | Notes                                            |
+| ------------------------- | ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| **Telink Zephyr SDK**     | [telink-semi/tl_zephyr](https://github.com/telink-semi/tl_zephyr)                   | [`ec302e9`](https://github.com/telink-semi/tl_zephyr/commit/ec302e94cb2886f0c71515efbe7344b32449a9ff)          | TL521x SoC split + radio reset for Zigbee→Matter |
+| **Telink BLE SDK**        | [telink-semi/tl_ble_sdk_zephyr](https://github.com/telink-semi/tl_ble_sdk_zephyr)   | [`de6f125`](https://github.com/telink-semi/tl_ble_sdk_zephyr/commit/de6f125c8ae6d29c4a640ab3526b40ff8c3f0a20)  | Required by TL521X                               |
+| **Telink HAL Zephyr**     | [telink-semi/hal_telink](https://github.com/telink-semi/hal_telink)                 | [`bd870dc`](https://github.com/telink-semi/hal_telink/commit/bd870dc273989756f908077761a5e3adbd7d108f)         | Contains hal_v1 and hal_v2 sources               |
+| **MCUBoot**               | [telink-semi/tl_mcuboot](https://github.com/telink-semi/tl_mcuboot)                 | [`ce0da85`](https://github.com/telink-semi/tl_mcuboot/commit/ce0da85c39c749df49b0ec62b33d2ecdea24c927)         | Bootloader; required for OTA/DFU                 |
+| **OpenThread Telink**     | [telink-semi/tl_openthread](https://github.com/telink-semi/tl_openthread)           | [`542aaab`](https://github.com/telink-semi/tl_openthread/commit/542aaab44e1308e1a8a24573dfbd413fade342ee)      | OpenThread source adapted for Telink             |
+| **OpenThread Telink Lib** | [telink-semi/tl_openthread_libs](https://github.com/telink-semi/tl_openthread_libs) | [`f69c186`](https://github.com/telink-semi/tl_openthread_libs/commit/f69c186d65a41259480e87ccf9d2a7f665249778) | Pre-built OpenThread library for Telink          |
+| **Telink XZ (LZMA)**      | [telink-semi/tl_xz](https://github.com/telink-semi/tl_xz)                           | [`831f338`](https://github.com/telink-semi/tl_xz/commit/831f338fd6784661d3bec62fd01060ee4d7d373d)              | LZMA compression library module                  |
 
 -   Updated Zephyr SDK references from `telink-semi/zephyr` to
     `telink-semi/tl_zephyr` (repo renamed, links updated accordingly).


### PR DESCRIPTION
#### Summary

Finalize the v1.4.0 release notes and add a Mergify backport rule for
release-v1.4-v1.5-branch:

- Remove the dev-tlk_v1.5 / dev-tlk_v4.1 branch references from the v1.4.0
  release notes; the release is pinned to commits/tags, not branches.
- Fix the Version badge shields.io escaping (tl__v1.4.0--v1.5) so the badge
  renders correctly instead of showing "badge not found".
- Add a Mergify backport rule so changes merged to dev-tlk_v1.5 can be
  backported to release-v1.4-v1.5-branch.

#### Related issues

N/A

#### Testing

- Release notes: verified with prettier 1.19.1 (--check) and markdownlint;
  the corrected badge URL was verified to render the expected label/message.
- Mergify config: validated that .mergify.yml parses and the new rule follows
  the existing Telink backport rule structure.

#### Readability checklist

-   [x] PR title is
        `https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting`
-   [x] Apply the
        `https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html`
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: `https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated Telink Matter SDK release notes with revised version badges, formatting, and reference links.
  - Refined feature, bug-fix, and dependency information, including removal of outdated branch references and tracking notes.
  - Updated English and Chinese README wording, resource links, and section references.
- **Chores**
  - Improved automated backport handling for selected release branches.
  - Preserved existing prose wrapping in Markdown documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->